### PR TITLE
Make Home/End keys behavior more standard

### DIFF
--- a/src/PrettyPrompt/Completion/SlidingArrayWindow.cs
+++ b/src/PrettyPrompt/Completion/SlidingArrayWindow.cs
@@ -29,9 +29,7 @@ namespace PrettyPrompt.Completion
         {
             this.array = array;
             this.windowLength = windowLength;
-            this.windowStart = array.Length - windowLength <= 0 
-                ? 0
-                : Math.Min(selectedIndex, array.Length - windowLength);
+            this.windowStart = CalculateWindowStart(array, windowLength, selectedIndex);
             this.selectedIndex = selectedIndex;
             this.windowBuffer = windowBuffer;
         }
@@ -70,6 +68,11 @@ namespace PrettyPrompt.Completion
             selectedIndex = 0;
             windowStart = 0;
         }
+
+        private static int CalculateWindowStart(T[] array, int windowLength, int selectedIndex) =>
+            array.Length - windowLength <= 0
+            ? 0
+            : Math.Min(selectedIndex, array.Length - windowLength);
 
         public IEnumerator<T> GetEnumerator() =>
             AsArraySegment().GetEnumerator();

--- a/src/PrettyPrompt/History/HistoryLog.cs
+++ b/src/PrettyPrompt/History/HistoryLog.cs
@@ -136,18 +136,28 @@ namespace PrettyPrompt.History
 
         internal void Track(CodePane codePane)
         {
-            if (current?.Previous != null) // Not first?
-            {
-                if (string.IsNullOrEmpty(history.Last?.Value.ToString()) ||
-                    history.Last?.Value.ToString() == history.Last?.Previous?.Value.ToString())
-                {
-                    // Remove last empty/duplicate history.
-                    history.RemoveLast();
-                }
-            }
-
+            PruneHistory(history);
             current = history.AddLast(codePane.Input);
             latestCodePane = codePane;
+        }
+
+        /// <summary>
+        /// Remove the latest history entry, if it's empty or duplicate.
+        /// </summary>
+        private static void PruneHistory(LinkedList<StringBuilder> history)
+        {
+            if (!history.Any())
+            {
+                return;
+            }
+
+            var previousEntry = history.Last?.Value.ToString();
+            var penultimateEntry = history.Last?.Previous?.Value.ToString();
+            if (string.IsNullOrEmpty(previousEntry) || previousEntry == penultimateEntry)
+            {
+                // Remove last empty/duplicate history.
+                history.RemoveLast();
+            }
         }
 
         internal async Task SavePersistentHistoryAsync(StringBuilder input)

--- a/src/PrettyPrompt/Panes/CodePane.cs
+++ b/src/PrettyPrompt/Panes/CodePane.cs
@@ -70,9 +70,15 @@ namespace PrettyPrompt.Panes
                     Result = new PromptResult(IsSuccess: true, Input.ToString().EnvironmentNewlines(), IsHardEnter: false);
                     break;
                 case Home:
-                    Caret = 0;
+                    Caret = CalculateLineBoundaryIndex(Input, Caret, -1);
                     break;
                 case End:
+                    Caret = CalculateLineBoundaryIndex(Input, Caret, +1);
+                    break;
+                case (Control, Home):
+                    Caret = 0;
+                    break;
+                case (Control, End):
                     Caret = Input.Length;
                     break;
                 case LeftArrow:
@@ -197,6 +203,23 @@ namespace PrettyPrompt.Panes
             }
 
             static bool IsWordStart(char c1, char c2) => !char.IsLetterOrDigit(c1) && char.IsLetterOrDigit(c2);
+
+            return bound;
+        }
+
+        private static int CalculateLineBoundaryIndex(StringBuilder input, int caret, int direction)
+        {
+            if (input.Length == 0) return caret;
+
+            if (direction == +1 && caret < input.Length && input[caret] == '\n') return caret;
+
+            int bound = direction > 0 ? input.Length : 0;
+
+            for (var i = caret + direction; bound == 0 ? i > 0 : i < bound; i += direction)
+            {
+                if (input[i] == '\n')
+                    return i + (direction == -1 ? 1 : 0);
+            }
 
             return bound;
         }

--- a/src/PrettyPrompt/Panes/CompletionPane.cs
+++ b/src/PrettyPrompt/Panes/CompletionPane.cs
@@ -18,8 +18,8 @@ namespace PrettyPrompt.Panes
 {
     internal class CompletionPane : IKeyPressHandler
     {
-        const int MAX_HEIGHT = 10;
-        const int VERTICAL_PADDING = 3; // cursor + top border + bottom border.
+        private const int MaxCompletionCount = 10;
+        private const int VerticalPaddingHeight = 3; // cursor + top border + bottom border.
 
         private readonly CodePane codePane;
         private readonly CompletionCallbackAsync complete;
@@ -106,6 +106,10 @@ namespace PrettyPrompt.Panes
                 case (Control, Spacebar):
                     key.Handled = true;
                     break;
+                case Home:
+                case End:
+                case (Control, Home):
+                case (Control, End):
                 case LeftArrow:
                     Close();
                     key.Handled = false;
@@ -124,7 +128,7 @@ namespace PrettyPrompt.Panes
         }
 
         private bool EnoughRoomToDisplay(CodePane codePane) =>
-            codePane.CodeAreaHeight - (codePane.Cursor?.Row).GetValueOrDefault(0) >= VERTICAL_PADDING + 1; // offset + top border + 1 completion item + bottom border
+            codePane.CodeAreaHeight - (codePane.Cursor?.Row).GetValueOrDefault(0) >= VerticalPaddingHeight + 1; // offset + top border + 1 completion item + bottom border
 
         async Task IKeyPressHandler.OnKeyUp(KeyPress key)
         {
@@ -183,9 +187,7 @@ namespace PrettyPrompt.Panes
 
         private void FilterCompletions(CodePane codePane)
         {
-            int height = Math.Min(
-                codePane.CodeAreaHeight - VERTICAL_PADDING, 
-                MAX_HEIGHT);
+            int height = Math.Min(codePane.CodeAreaHeight - VerticalPaddingHeight, MaxCompletionCount);
 
             var filtered = new List<CompletionItem>();
             var previouslySelectedItem = this.FilteredView.SelectedItem;

--- a/src/PrettyPrompt/Panes/WordWrapping.cs
+++ b/src/PrettyPrompt/Panes/WordWrapping.cs
@@ -72,7 +72,6 @@ namespace PrettyPrompt.Panes
             return new WordWrappedText(lines, cursor);
         }
 
-
         /// <summary>
         /// Wrap words into lines of at most maxLength long. Split on spaces
         /// where possible, otherwise split by character if a single word is

--- a/tests/PrettyPrompt.Tests/CompletionTestData.cs
+++ b/tests/PrettyPrompt.Tests/CompletionTestData.cs
@@ -18,7 +18,7 @@ namespace PrettyPrompt.Tests
 
         public CompletionTestData(IReadOnlyCollection<string> completions = null)
         {
-            this.completions = completions ?? new[] {"Aardvark", "Albatross", "Alligator", "Alpaca", "Ant", "Anteater", "Zebra" };
+            this.completions = completions ?? new[] {"Aardvark", "Albatross", "Alligator", "Alpaca", "Ant", "Anteater", "Baboon", "Cat", "Dog", "Elephant", "Fox", "Zebra" };
         }
 
         public Task<IReadOnlyList<CompletionItem>> CompletionHandlerAsync(string text, int caret)

--- a/tests/PrettyPrompt.Tests/CompletionTests.cs
+++ b/tests/PrettyPrompt.Tests/CompletionTests.cs
@@ -79,6 +79,55 @@ namespace PrettyPrompt.Tests
         }
 
         [Fact]
+        public async Task ReadLine_CompletionMenu_Closes()
+        {
+            var console = ConsoleStub.NewConsole();
+            Prompt prompt = ConfigurePrompt(console);
+
+            // Escape should close menu
+            console.StubInput($"A{Escape}{Enter}"); // it will auto-open when we press A (see previous test)
+            var result = await prompt.ReadLineAsync("> ");
+
+            Assert.True(result.IsSuccess);
+            Assert.Equal($"A", result.Text);
+
+            // Home key (among others) should close menu
+            console.StubInput($"A{Home}{Enter}");
+            var result2 = await prompt.ReadLineAsync("> ");
+
+            Assert.True(result2.IsSuccess);
+            Assert.Equal($"A", result2.Text);
+        }
+
+        [Fact]
+        public async Task ReadLine_CompletionMenu_Scrolls()
+        {
+            var console = ConsoleStub.NewConsole();
+            console.StubInput(
+                $"{Control}{Spacebar}{Control}{Spacebar}",
+                $"{DownArrow}{DownArrow}{DownArrow}{DownArrow}{DownArrow}{DownArrow}{DownArrow}{DownArrow}{DownArrow}{DownArrow}{DownArrow}",
+                $"{Enter}{Enter}"
+            );
+            Prompt prompt = ConfigurePrompt(console);
+
+            var result = await prompt.ReadLineAsync("> ");
+
+            Assert.True(result.IsSuccess);
+            Assert.Equal($"Zebra", result.Text);
+
+            console.StubInput(
+                $"{Control}{Spacebar}{Control}{Spacebar}",
+                $"{DownArrow}{DownArrow}{DownArrow}{DownArrow}{DownArrow}{DownArrow}{DownArrow}{DownArrow}{DownArrow}{DownArrow}{DownArrow}",
+                $"{UpArrow}{UpArrow}{UpArrow}{UpArrow}{UpArrow}{UpArrow}{UpArrow}{UpArrow}{UpArrow}{UpArrow}{UpArrow}",
+                $"{Enter}{Enter}"
+            );
+
+            var result2 = await prompt.ReadLineAsync("> ");
+            Assert.True(result2.IsSuccess);
+            Assert.Equal($"Aardvark", result2.Text);
+        }
+
+        [Fact]
         public async Task ReadLine_FullyTypeCompletion_CanOpenAgain()
         {
             var console = ConsoleStub.NewConsole();

--- a/tests/PrettyPrompt.Tests/PromptTests.cs
+++ b/tests/PrettyPrompt.Tests/PromptTests.cs
@@ -235,7 +235,7 @@ namespace PrettyPrompt.Tests
                 .Returns(true, $"   indent\r        more indent\r\r    inden".Select(_ => true).Append(false).ToArray());
             console.StubInput($"    indent\r        more indent\r\r    indent{Enter}");
 
-            var prompt = new Prompt( console: console);
+            var prompt = new Prompt(console: console);
 
             var result = await prompt.ReadLineAsync("> ");
 

--- a/tests/PrettyPrompt.Tests/PromptTests.cs
+++ b/tests/PrettyPrompt.Tests/PromptTests.cs
@@ -119,6 +119,21 @@ namespace PrettyPrompt.Tests
         }
 
         [Fact]
+        public async Task ReadLine_HomeEndKeys_NavigateLines()
+        {
+            var console = ConsoleStub.NewConsole();
+            console.StubInput(
+                $"{Shift}{Enter}{Shift}{Enter}hello{Home}{Delete}H{End}!{Shift}{Enter}",
+                $"world{Control}{Home}I say:{Control}{End}!{Home}{Delete}W{Enter}"
+            );
+
+            var prompt = new Prompt(console: console);
+            var result = await prompt.ReadLineAsync("> ");
+
+            Assert.Equal($"I say:{NewLine}{NewLine}Hello!{NewLine}World!", result.Text);
+        }
+
+        [Fact]
         public async Task ReadLine_VerticalNavigationKeys()
         {
             var console = ConsoleStub.NewConsole();


### PR DESCRIPTION
Currently, the Home / End keys navigate to the start / end of the entire prompt text, even if it's multiline. In the example text below, if the caret was at the very beginning of the text (before the first `a`), pressing End would navigate to the last `c`.

```
aaaa
bbbb
cccc
```

This is a bit unintuitive; most would expect End to navigate past the final `a` (and stay on the "first line" of the multiline text).

This PR fixes that, and also adds Control-Home and Control-End to navigate to the first/last characters of the multiline text.