### PR TITLE
Rework how CJK (full width) characters are treated

### DIFF
--- a/examples/PrettyPrompt.Examples.FruitPrompt/Program.cs
+++ b/examples/PrettyPrompt.Examples.FruitPrompt/Program.cs
@@ -10,7 +10,7 @@ namespace PrettyPrompt
 {
     internal static class Program
     {
-        static async Task Main(string[] args)
+        static async Task Main(string[] _)
         {
             Console.WriteLine("Welcome! Try typing some fruit names.");
             Console.WriteLine();
@@ -44,7 +44,7 @@ namespace PrettyPrompt
         }
 
         // demo data
-        private static (string name, string description, AnsiColor highlight)[] Fruits = new[]
+        private static readonly (string name, string description, AnsiColor highlight)[] Fruits = new[]
         {
             ( "apple", "the round fruit of a tree of the rose family, which typically has thin red or green skin and crisp flesh. Many varieties have been developed as dessert or cooking fruit or for making cider.", AnsiColor.BrightRed ),
             ( "apricot", "a juicy, soft fruit, resembling a small peach, of an orange-yellow color.", AnsiColor.Yellow ),

--- a/src/PrettyPrompt/Rendering/IncrementalRendering.cs
+++ b/src/PrettyPrompt/Rendering/IncrementalRendering.cs
@@ -23,7 +23,7 @@ namespace PrettyPrompt.Rendering
         /// A more complicated case, like finishing a word that triggers syntax highlighting, we should redraw just that word in the new color.
         /// An even more complicated case, like opening the autocomplete menu, should draw the autocomplete menu, and return the cursor to the correct position.
         /// </summary>
-        public static string CalculateDiff(Screen currentScreen, Screen previousScreen, ConsoleCoordinate ansiCoordinate, ConsoleCoordinate cursor)
+        public static string CalculateDiff(Screen currentScreen, Screen previousScreen, ConsoleCoordinate ansiCoordinate)
         {
             var diff = new StringBuilder();
 
@@ -36,36 +36,28 @@ namespace PrettyPrompt.Rendering
                 column: ansiCoordinate.Column + previousScreen.Cursor.Column
             );
 
-            // for "latin" characters, where each character is a single character-width, this horizontalRenderPosition isn't strictly needed.
-            // however, for CJK character, each character is two character-widths, so we need to track "index of the character we're rendering" and
-            // the "coordinate at which we're rendering" separately.
-            int currentHorizontalRenderPosition = 0;
-            int previousHorizontalRenderPosition = 0;
             foreach (var (i, currentCell, previousCell) in currentScreen.CellBuffer.ZipLongest(previousScreen.CellBuffer))
             {
-                if(i % currentScreen.Width == 0)
+                if (currentCell is not null && currentCell.IsContinuationOfPreviousCharacter)
                 {
-                    currentHorizontalRenderPosition = 0;
-                    previousHorizontalRenderPosition = 0;
+                    continue;
                 }
 
-                previousHorizontalRenderPosition += previousCell?.CellWidth ?? 1;
-                if(currentCell == previousCell)
+                if (currentCell == previousCell)
                 {
-                    currentHorizontalRenderPosition += currentCell?.CellWidth ?? 1;
                     continue;
                 }
 
                 var cellCoordinate = new ConsoleCoordinate(
                     row: ansiCoordinate.Row + (i / currentScreen.Width),
-                    column: ansiCoordinate.Column + currentHorizontalRenderPosition
+                    column: ansiCoordinate.Column + (i % currentScreen.Width)
                 );
 
                 MoveCursorIfRequired(diff, previousCoordinate, cellCoordinate);
                 previousCoordinate.Row = cellCoordinate.Row;
                 previousCoordinate.Column = cellCoordinate.Column;
 
-                // Part 1: handle when we're erasing characters/formatting from the previously rendered screen.
+                // handle when we're erasing characters/formatting from the previously rendered screen.
                 if (currentCell?.Formatting == null)
                 {
                     if (currentFormatRun is not null)
@@ -74,27 +66,19 @@ namespace PrettyPrompt.Rendering
                         currentFormatRun = null;
                     }
 
-                    if (currentCell?.Text is null || (currentCell.Text == "\n" && previousCell is not null)) // no character, or a newline which should erase the cell in which it was typed.
+                    if (currentCell?.Text is null || currentCell.Text == "\n")
                     {
-                        var eraseWidth = previousHorizontalRenderPosition - currentHorizontalRenderPosition;
-                        if(eraseWidth > 0)
-                        {
-                            diff.Append(' ', eraseWidth);
-                            UpdateCoordinateFromCursorMove(previousScreen, ansiCoordinate, diff, previousCoordinate, previousCell, eraseWidth);
+                        diff.Append(' ');
+                        UpdateCoordinateFromCursorMove(previousScreen, ansiCoordinate, diff, previousCoordinate, currentCell);
 
-                            if (currentCell is null)
-                            {
-                                currentHorizontalRenderPosition += eraseWidth;
-                            }
+                        if (currentCell is null)
+                        {
+                            continue;
                         }
-                    }
-                    if (currentCell is null)
-                    {
-                        continue;
                     }
                 }
 
-                // Part 2: write out current character, with any formatting
+                // write out current character, with any formatting
                 if (currentCell.Formatting != currentFormatRun)
                 {
                     diff.Append(
@@ -108,7 +92,6 @@ namespace PrettyPrompt.Rendering
                     diff.Append(currentCell.Text);
                 }
 
-                // Part 3: update internal tracking of cursor movement.
                 // writing to the console will automatically move the cursor.
                 // update our internal tracking so we calculate the least
                 // amount of movement required for the next character.
@@ -118,9 +101,8 @@ namespace PrettyPrompt.Rendering
                 }
                 else
                 {
-                    UpdateCoordinateFromCursorMove(currentScreen, ansiCoordinate, diff, previousCoordinate, currentCell, currentCell.CellWidth);
+                    UpdateCoordinateFromCursorMove(currentScreen, ansiCoordinate, diff, previousCoordinate, currentCell);
                 }
-                currentHorizontalRenderPosition += currentCell.CellWidth;
             }
 
             if (currentFormatRun is not null)
@@ -131,30 +113,42 @@ namespace PrettyPrompt.Rendering
             // all done rendering, update the cursor position if we need to. If we rendered the
             // autocomplete menu, or if the cursor is manually positioned in the middle of
             // the text, the cursor won't be in the correct position.
-            MoveCursorIfRequired(diff, fromCoordinate: previousCoordinate, toCoordinate: new ConsoleCoordinate(
-                cursor.Row + ansiCoordinate.Row,
-                cursor.Column + ansiCoordinate.Column
-            ));
+            MoveCursorIfRequired(
+                diff,
+                fromCoordinate: previousCoordinate,
+                toCoordinate: new ConsoleCoordinate(
+                    currentScreen.Cursor.Row + ansiCoordinate.Row,
+                    currentScreen.Cursor.Column + ansiCoordinate.Column
+                )
+            );
 
             return diff.ToString();
         }
 
-        private static void UpdateCoordinateFromCursorMove(
-            Screen currentScreen, ConsoleCoordinate ansiCoordinate, StringBuilder diff, ConsoleCoordinate previousCoordinate, Cell currentCell, int moveCount)
+        private static void UpdateCoordinateFromCursorMove(Screen currentScreen, ConsoleCoordinate ansiCoordinate, StringBuilder diff, ConsoleCoordinate previousCoordinate, Cell currentCell)
         {
+            var characterWidth = currentCell is null ? 1 : currentCell.ElementWidth;
             // if we hit the edge of the screen, wrap
-            bool hitRightEdgeOfScreen = previousCoordinate.Column + moveCount == currentScreen.Width + ansiCoordinate.Column;
+            bool hitRightEdgeOfScreen = previousCoordinate.Column + characterWidth == currentScreen.Width + ansiCoordinate.Column;
             if (hitRightEdgeOfScreen)
             {
                 if(currentCell is not null && !currentCell.TruncateToScreenHeight)
                 {
                     diff.Append('\n');
                     UpdateCoordinateFromNewLine(previousCoordinate);
+                    if(characterWidth == 2)
+                    {
+                        previousCoordinate.Column++;
+                    }
                 }
             }
             else
             {
-                previousCoordinate.Column += moveCount;
+                previousCoordinate.Column++;
+                if(characterWidth == 2)
+                {
+                    previousCoordinate.Column++;
+                }
             }
         }
 

--- a/src/PrettyPrompt/Rendering/Renderer.cs
+++ b/src/PrettyPrompt/Rendering/Renderer.cs
@@ -104,7 +104,7 @@ namespace PrettyPrompt
 
             // calculate the diff between the previous screen and the
             // screen to be drawn, and output that diff.
-            string outputDiff = IncrementalRendering.CalculateDiff(screen, previouslyRenderedScreen, ansiCoordinate, codePane.Cursor);
+            string outputDiff = IncrementalRendering.CalculateDiff(screen, previouslyRenderedScreen, ansiCoordinate);
             previouslyRenderedScreen = screen;
 
             Write(outputDiff, outputDiff.Length > 64);
@@ -125,6 +125,14 @@ namespace PrettyPrompt
         private static ScreenArea BuildCodeScreenArea(CodePane codePane, IReadOnlyCollection<FormatSpan> highlights)
         {
             var highlightedLines = HighlightRenderer.ApplyColorToCharacters(highlights, codePane.WordWrappedLines);
+            // if we've filled up the full line, add a new line at the end so we can render our cursor on this new line.
+            if(highlightedLines[^1].Cells.Count > 0
+                && (highlightedLines[^1].Cells.Count >= codePane.CodeAreaWidth
+                    || highlightedLines[^1].Cells[^1]?.Text == "\n"))
+            {
+                Array.Resize(ref highlightedLines, highlightedLines.Length + 1);
+                highlightedLines[^1] = new Row(new List<Cell>());
+            }
             var codeWidget = new ScreenArea(new ConsoleCoordinate(0, 0), highlightedLines, TruncateToScreenHeight: false);
             return codeWidget;
         }

--- a/tests/PrettyPrompt.Tests/ChineseJapaneseKoreanTests.cs
+++ b/tests/PrettyPrompt.Tests/ChineseJapaneseKoreanTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using PrettyPrompt.Consoles;
+using System.Threading.Tasks;
 using Xunit;
 using static System.ConsoleKey;
 
@@ -68,6 +69,26 @@ namespace PrettyPrompt.Tests
             var result = await prompt.ReadLineAsync("> ");
 
             Assert.Equal("书桌上有", result.Text);
+        }
+
+        [Fact]
+        public async Task ReadLineAsync_TypesCJKTextInNarrowWindow_Wraps()
+        {
+            // prompt takes up 2 characters, with 3 full-width characters: 2 + 2*3 = 8
+            var console = ConsoleStub.NewConsole(width: 8);
+            // final character should wrap to next line.
+            console.StubInput($"书桌上有{Enter}");
+
+            var prompt = new Prompt(console: console);
+            var result = await prompt.ReadLineAsync("> ");
+
+            var output = console.GetAllOutput();
+
+            Assert.Equal("书桌上有", result.Text);
+            Assert.Contains("书", output);
+            Assert.Contains("桌", output);
+            Assert.Contains("上" + "\n" + AnsiEscapeCodes.MoveCursorLeft(5), output);
+            Assert.Contains("有", output);
         }
     }
 }

--- a/tests/PrettyPrompt.Tests/SyntaxHighlighterTestData.cs
+++ b/tests/PrettyPrompt.Tests/SyntaxHighlighterTestData.cs
@@ -10,16 +10,21 @@ using System.Threading.Tasks;
 
 namespace PrettyPrompt.Tests
 {
-    public static class SyntaxHighlighterTestData
+    public class SyntaxHighlighterTestData
     {
-        private static readonly IReadOnlyDictionary<string, AnsiColor> highlights = new Dictionary<string, AnsiColor>()
-        {
-            { "red", AnsiColor.BrightRed },
-            { "green", AnsiColor.BrightGreen },
-            { "blue", AnsiColor.BrightBlue },
-        };
+        private readonly IReadOnlyDictionary<string, AnsiColor> highlights;
 
-        public static Task<IReadOnlyCollection<FormatSpan>> HighlightHandlerAsync(string text)
+        public SyntaxHighlighterTestData(IReadOnlyDictionary<string, AnsiColor> colors = null)
+        {
+            this.highlights = colors ?? new Dictionary<string, AnsiColor>()
+            {
+                { "red", AnsiColor.BrightRed },
+                { "green", AnsiColor.BrightGreen },
+                { "blue", AnsiColor.BrightBlue },
+            };
+        }
+
+        public Task<IReadOnlyCollection<FormatSpan>> HighlightHandlerAsync(string text)
         {
             var spans = new List<FormatSpan>();
 

--- a/tests/PrettyPrompt.Tests/SyntaxHighlightingTests.cs
+++ b/tests/PrettyPrompt.Tests/SyntaxHighlightingTests.cs
@@ -4,6 +4,8 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #endregion
 
+using PrettyPrompt.Highlighting;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
 using static PrettyPrompt.Consoles.AnsiEscapeCodes;
@@ -22,7 +24,7 @@ namespace PrettyPrompt.Tests
             var prompt = new Prompt(
                 callbacks: new PromptCallbacks
                 {
-                    HighlightCallback = SyntaxHighlighterTestData.HighlightHandlerAsync
+                    HighlightCallback = new SyntaxHighlighterTestData().HighlightHandlerAsync
                 },
                 console: console
             );
@@ -49,6 +51,55 @@ namespace PrettyPrompt.Tests
             );
 
             Assert.DoesNotContain("nocolor", output); // it should output character by character as we type; never the whole string at once.
+        }
+
+        [Fact]
+        public async Task ReadLine_CJKCharacters_SyntaxHighlight()
+        {
+            var console = ConsoleStub.NewConsole(width: 20);
+            console.StubInput($"苹果 o 蓝莓 o avocado o{Enter}");
+
+            var prompt = new Prompt(
+                callbacks: new PromptCallbacks
+                {
+                    HighlightCallback = new SyntaxHighlighterTestData(new Dictionary<string, AnsiColor>
+                    {
+                        { "苹果", AnsiColor.Red },
+                        { "蓝莓", AnsiColor.Blue },
+                        { "avocado", AnsiColor.Green }
+                    }).HighlightHandlerAsync
+                },
+                console: console
+            );
+
+            var result = await prompt.ReadLineAsync("> ");
+
+            Assert.True(result.IsSuccess);
+            Assert.Equal("苹果 o 蓝莓 o avocado o", result.Text);
+            var output = console.GetAllOutput();
+
+            // although the words are typed character-by-character, we should still "go back" and redraw
+            // it once we know the word should be drawn in a syntax-highlighted color.
+            Assert.Contains(
+                MoveCursorLeft(2) + Red + "苹果" + Reset,
+                output
+            );
+
+            Assert.Contains(
+                MoveCursorLeft(2) + Blue + "蓝莓" + Reset,
+                output
+            );
+
+            // avocado is green, but wrapped because the console width is narrow.
+            Assert.Contains(
+                output,
+                str => str.Contains(Green + "avoc\n")
+            );
+
+            Assert.Contains(
+                output,
+                str => str.Contains("ado" + Reset)
+            );
         }
     }
 }

--- a/tests/PrettyPrompt.Tests/WordWrappingTests.cs
+++ b/tests/PrettyPrompt.Tests/WordWrappingTests.cs
@@ -1,10 +1,6 @@
 ﻿using PrettyPrompt.Consoles;
 using PrettyPrompt.Panes;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace PrettyPrompt.Tests
@@ -31,21 +27,42 @@ namespace PrettyPrompt.Tests
         }
 
         [Fact]
-        public void WrapEditableCharacters_DoubleWidthCharacters_UsesUnicodeWidth()
+        public void WrapEditableCharacters_DoubleWidthCharacters_UsesStringWidth()
         {
             var text = "每个人都有他的作战策略，直到脸上中了一拳。";
-            var wrapped = WordWrapping.WrapEditableCharacters(new StringBuilder(text), 13, 20);
+            var wrapped = WordWrapping.WrapEditableCharacters(new StringBuilder(text), initialCaretPosition: 13, width: 20);
 
             Assert.Equal(
                 new[]
                 {
                     new WrappedLine(0, "每个人都有他的作战策"),
-                    new WrappedLine(20, "略，直到脸上中了一拳"),
-                    new WrappedLine(40, "。"),
+                    new WrappedLine(10, "略，直到脸上中了一拳"),
+                    new WrappedLine(20, "。"),
                 },
                 wrapped.WrappedLines
             );
-            Assert.Equal(new ConsoleCoordinate(1, 6), wrapped.Cursor);
+            Assert.Equal(new ConsoleCoordinate(1, 3), wrapped.Cursor);
+        }
+
+
+        [Fact]
+        public void WrapEditableCharacters_DoubleWidthCharactersWithWrappingInMiddleOfCharacter_WrapsCharacter()
+        {
+            var text = "每个人都有他的作战策略， 直到脸上中了一拳。";
+            var wrapped = WordWrapping.WrapEditableCharacters(new StringBuilder(text), initialCaretPosition: 19, width: 19);
+
+            Assert.Equal(
+                new[]
+                {
+                    new WrappedLine(0, "每个人都有他的作战"),  // case 1: we should wrap early, because the next character is a full-width (2-wide) character.
+                    new WrappedLine(9, "策略， 直到脸上中了"), // case 2: single width space ("normal" space) sets us to align to width 19 exactly.
+                    new WrappedLine(19, "一拳。")
+                },
+                wrapped.WrappedLines
+            );
+
+            Assert.Equal(new ConsoleCoordinate(2, 0), wrapped.Cursor);
+
         }
 
         [Fact]


### PR DESCRIPTION
Previously, full-width CJK characters were only handled in the renderer, which led to some workarounds and made syntax highlighting tricky. This changes it so we account for full-width characters in our data model directly (e.g. Screen/Row/Cell) which leads to a simpler renderer and solves for syntax highlighting and word wrapping edge cases.

Closes #1

Here's a screenshot of this branch being used in csharprepl:

![image](https://user-images.githubusercontent.com/97195/121727995-dcdb2300-cb16-11eb-8820-d73754323374.png)
