### PR TITLE
Add support for Ctrl+Function ansi input escape sequences

### DIFF
--- a/examples/PrettyPrompt.Examples.FruitPrompt/Program.cs
+++ b/examples/PrettyPrompt.Examples.FruitPrompt/Program.cs
@@ -142,7 +142,7 @@ namespace PrettyPrompt
                     OperatingSystem.IsMacOS() ? new ProcessStartInfo("open", url) :
                     new ProcessStartInfo("xdg-open", url); //linux, unix-like
 
-                Process.Start(browser);
+                Process.Start(browser).WaitForExit();
             }
         }
     }

--- a/src/PrettyPrompt/Console/KeyPress.cs
+++ b/src/PrettyPrompt/Console/KeyPress.cs
@@ -56,8 +56,15 @@ namespace PrettyPrompt.Consoles
                 // for each key press, which is slow. Instead, batch them up to send as single "pasted text" block.
                 var keys = ReadRemainingKeys(console, key);
 
-                if (keys.Count < 4 || keys.All(k => char.IsControl(k.KeyChar))) // 4 is not special here, just seemed like a decent number to separate
-                                                                                // between "keys pressed simultaneously" and "pasted text"
+                if (key.Key == ConsoleKey.Escape)
+                {
+                    if(MapInputEscapeSequence(keys) is KeyPress ansiEscapedInput)
+                    {
+                        yield return ansiEscapedInput;
+                    }
+                }
+                else if (keys.Count < 4 || keys.All(k => char.IsControl(k.KeyChar))) // 4 is not special here, just seemed like a decent number to separate
+                                                                                     // between "keys pressed simultaneously" and "pasted text"
                 {
                     foreach (var consoleKey in keys)
                     {
@@ -73,6 +80,30 @@ namespace PrettyPrompt.Consoles
                     );
                 }
             }
+        }
+
+        /// <summary>
+        /// On Linux, .NET doesn't map all the ANSI escaped inputs into ConsoleKeyInfos. Map some of the missing ones here.
+        /// </summary>
+        private static KeyPress MapInputEscapeSequence(List<ConsoleKeyInfo> keys)
+        {
+            var sequence = new string(keys.Select(key => key.KeyChar).ToArray());
+            return sequence switch
+            {
+                "\u001b1;5P" => new KeyPress(new ConsoleKeyInfo('\0', ConsoleKey.F1, shift: false, alt: false, control: true)),
+                "\u001b1;5Q" => new KeyPress(new ConsoleKeyInfo('\0', ConsoleKey.F2, shift: false, alt: false, control: true)),
+                "\u001b1;5R" => new KeyPress(new ConsoleKeyInfo('\0', ConsoleKey.F3, shift: false, alt: false, control: true)),
+                "\u001b1;5S" => new KeyPress(new ConsoleKeyInfo('\0', ConsoleKey.F4, shift: false, alt: false, control: true)),
+                "\u001b15;5~" => new KeyPress(new ConsoleKeyInfo('\0', ConsoleKey.F5, shift: false, alt: false, control: true)),
+                "\u001b17;5~" => new KeyPress(new ConsoleKeyInfo('\0', ConsoleKey.F6, shift: false, alt: false, control: true)),
+                "\u001b18;5~" => new KeyPress(new ConsoleKeyInfo('\0', ConsoleKey.F7, shift: false, alt: false, control: true)),
+                "\u001b19;5~" => new KeyPress(new ConsoleKeyInfo('\0', ConsoleKey.F8, shift: false, alt: false, control: true)),
+                "\u001b20;5~" => new KeyPress(new ConsoleKeyInfo('\0', ConsoleKey.F9, shift: false, alt: false, control: true)),
+                "\u001b21;5~" => new KeyPress(new ConsoleKeyInfo('\0', ConsoleKey.F10, shift: false, alt: false, control: true)),
+                "\u001b23;5~" => new KeyPress(new ConsoleKeyInfo('\0', ConsoleKey.F11, shift: false, alt: false, control: true)),
+                "\u001b24;5~" => new KeyPress(new ConsoleKeyInfo('\0', ConsoleKey.F12, shift: false, alt: false, control: true)),
+                _ => null
+            };
         }
 
         /// <summary>

--- a/tests/PrettyPrompt.Tests/KeyPressTests.cs
+++ b/tests/PrettyPrompt.Tests/KeyPressTests.cs
@@ -1,0 +1,50 @@
+﻿using NSubstitute;
+using PrettyPrompt.Consoles;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace PrettyPrompt.Tests
+{
+    public class KeyPressTests
+    {
+        [Fact]
+        public void KeyPressKeys()
+        {
+            var console = ConsoleStub.NewConsole();
+            var keys = new (FormattableString input, ConsoleKey expectedKey, ConsoleModifiers expectedModifier)[]
+            {
+                ($"\u001b1;5P", ConsoleKey.F1, ConsoleModifiers.Control),
+                ($"\u001b1;5Q", ConsoleKey.F2, ConsoleModifiers.Control),
+                ($"\u001b1;5R", ConsoleKey.F3, ConsoleModifiers.Control),
+                ($"\u001b1;5S", ConsoleKey.F4, ConsoleModifiers.Control),
+                ($"\u001b15;5~", ConsoleKey.F5, ConsoleModifiers.Control),
+                ($"\u001b17;5~", ConsoleKey.F6, ConsoleModifiers.Control),
+                ($"\u001b18;5~", ConsoleKey.F7, ConsoleModifiers.Control),
+                ($"\u001b19;5~", ConsoleKey.F8, ConsoleModifiers.Control),
+                ($"\u001b20;5~", ConsoleKey.F9, ConsoleModifiers.Control),
+                ($"\u001b21;5~", ConsoleKey.F10, ConsoleModifiers.Control),
+                ($"\u001b23;5~", ConsoleKey.F11, ConsoleModifiers.Control),
+                ($"\u001b24;5~", ConsoleKey.F12, ConsoleModifiers.Control),
+                ($"a", ConsoleKey.A, 0),
+                ($"pasted text", ConsoleKey.Insert, ConsoleModifiers.Shift)
+            };
+            console.StubInput(keys.Select(k => k.input).ToArray());
+
+            var keyAvailableResult = keys
+                .SelectMany(key => Enumerable.Repeat(true, key.input.ToString().Length - 1).Append(false))
+                .ToArray();
+            console
+                .KeyAvailable
+                .Returns(keyAvailableResult.First(), keyAvailableResult.Skip(1).ToArray());
+
+            var outputKeys = KeyPress.ReadForever(console).Take(keys.Length).ToArray();
+            Assert.Equal(keys.Length, outputKeys.Length);
+            foreach (var (expectedOutput, output) in keys.Zip(outputKeys))
+            {
+                Assert.Equal(expectedOutput.expectedKey, output.ConsoleKeyInfo.Key);
+                Assert.Equal(expectedOutput.expectedModifier, output.ConsoleKeyInfo.Modifiers);
+            }
+        }
+    }
+}


### PR DESCRIPTION
.NET does not map ctrl+function keys on linux, so we need to interpret the ansi escape sequences ourselves.