### PR TITLE
Allow custom keybindings to submit the prompt

### DIFF
--- a/examples/PrettyPrompt.Examples.FruitPrompt/Program.cs
+++ b/examples/PrettyPrompt.Examples.FruitPrompt/Program.cs
@@ -104,7 +104,7 @@ namespace PrettyPrompt
             return Task.FromResult<IReadOnlyCollection<FormatSpan>>(spans);
         }
 
-        private static Task ShowFruitDocumentation(string text, int caret)
+        private static Task<KeyPressCallbackResult> ShowFruitDocumentation(string text, int caret)
         {
             string wordUnderCursor = GetWordAtCaret(text, caret).ToLower();
 
@@ -114,7 +114,11 @@ namespace PrettyPrompt
                 LaunchBrowser("https://en.wikipedia.org/wiki/" + Uri.EscapeUriString(wordUnderCursor));
             }
 
-            return Task.CompletedTask;
+            // since we return a null KeyPressCallbackResult here, the user will remain on the current prompt
+            // and will still be able to edit the input.
+            // if we were to return a non-null result, this result will be returned from ReadLineAsync(). This
+            // is useful if we want our custom keypress to submit the prompt and control the output manually.
+            return Task.FromResult<KeyPressCallbackResult>(null);
 
             // local functions
             static string GetWordAtCaret(string text, int caret)

--- a/src/PrettyPrompt/Highlighting/CellRenderer.cs
+++ b/src/PrettyPrompt/Highlighting/CellRenderer.cs
@@ -17,7 +17,7 @@ namespace PrettyPrompt.Highlighting
     /// </summary>
     static class CellRenderer
     {
-        public static Row[] ApplyColorToCharacters(IReadOnlyCollection<FormatSpan> highlights, IReadOnlyList<WrappedLine> lines, List<SelectionSpan> selections)
+        public static Row[] ApplyColorToCharacters(IReadOnlyCollection<FormatSpan> highlights, IReadOnlyList<WrappedLine> lines, IList<SelectionSpan> selections)
         {
             var selectionStart = selections.Select(s => (s.Start.Row, s.Start.Column)).ToHashSet();
             var selectionEnd = selections.Select(s => (s.End.Row, s.End.Column)).ToHashSet();
@@ -92,6 +92,16 @@ namespace PrettyPrompt.Highlighting
             }
 
             return currentHighlight;
+        }
+
+        /// <summary>
+        /// This is just an extra function used by <see cref="Prompt.RenderAnsiOutput"/> that highlights arbitrary text. It's
+        /// not used for drawing input during normal functioning of the prompt.
+        /// </summary>
+        public static Row[] ApplyColorToCharacters(IReadOnlyCollection<FormatSpan> highlights, string text, int textWidth)
+        {
+            var wrapped = WordWrapping.WrapEditableCharacters(new System.Text.StringBuilder(text), 0, textWidth);
+            return ApplyColorToCharacters(highlights, wrapped.WrappedLines, Array.Empty<SelectionSpan>());
         }
     }
 }

--- a/src/PrettyPrompt/Prompt.cs
+++ b/src/PrettyPrompt/Prompt.cs
@@ -9,6 +9,7 @@ using PrettyPrompt.Consoles;
 using PrettyPrompt.Highlighting;
 using PrettyPrompt.History;
 using PrettyPrompt.Panes;
+using PrettyPrompt.Rendering;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -30,7 +31,7 @@ namespace PrettyPrompt
         private readonly SyntaxHighlighter highlighter;
 
         /// <summary>
-        /// Instantiates a prompt object. This object can be re-used for multiple lines of input.
+        /// Instantiates a prompt object. This object can be re-used for multiple invocations of <see cref="ReadLineAsync(string)"/>.
         /// </summary>
         /// <param name="persistentHistoryFilepath">The filepath of where to store history entries. If null, persistent history is disabled.</param>
         /// <param name="callbacks">A collection of callbacks for modifying and intercepting the prompt's behavior</param>
@@ -84,19 +85,17 @@ namespace PrettyPrompt
                 // render the typed input, with syntax highlighting
                 var inputText = codePane.Document.GetText();
                 var highlights = await highlighter.HighlightAsync(inputText).ConfigureAwait(false);
-                await renderer.RenderOutput(codePane, completionPane, highlights, key).ConfigureAwait(false);
 
-                // process any user-defined keyboard shortcuts
-                if (keyPressCallbacks.TryGetValue(key.Pattern, out var callback))
-                {
-                    await callback.Invoke(inputText, codePane.Document.Caret).ConfigureAwait(false);
-                }
+                // the key press may have caused the prompt to return its input, e.g. <Enter> or a callback.
+                var result = await GetResult(codePane, key, inputText).ConfigureAwait(false);
 
-                if (codePane.Result is not null)
+                await renderer.RenderOutput(result, codePane, completionPane, highlights, key).ConfigureAwait(false);
+
+                if (result is not null)
                 {
                     _ = history.SavePersistentHistoryAsync(inputText);
-                    cancellationManager.AllowControlCToCancelResult(codePane.Result);
-                    return codePane.Result;
+                    cancellationManager.AllowControlCToCancelResult(result);
+                    return result;
                 }
             }
 
@@ -115,8 +114,46 @@ namespace PrettyPrompt
                 await panes.OnKeyUp(key).ConfigureAwait(false);
         }
 
+        private async Task<PromptResult> GetResult(CodePane codePane, KeyPress key, string inputText)
+        {
+            // process any user-defined keyboard shortcuts
+            if (keyPressCallbacks.TryGetValue(key.Pattern, out var callback))
+            {
+                var result = await callback.Invoke(inputText, codePane.Document.Caret).ConfigureAwait(false);
+                if (result is not null)
+                    return result;
+            }
+            return codePane.Result;
+        }
+
         /// <inheritdoc cref="IPrompt.HasUserOptedOutFromColor" />
         public bool HasUserOptedOutFromColor { get; } = Environment.GetEnvironmentVariable("NO_COLOR") is not null;
+
+        /// <summary>
+        /// Given a string, and a collection of highlighting instructions, create ANSI Escape Sequence instructions that will 
+        /// draw the highlighted text to the console.
+        /// </summary>
+        /// <param name="text">the text to print</param>
+        /// <param name="formatting">the formatting instructions containing color information for the <paramref name="text"/></param>
+        /// <param name="textWidth">the width of the console. This controls the word wrapping, and can usually be <see cref="Console.BufferWidth"/>.</param>
+        /// <returns>A string of escape sequences that will draw the <paramref name="text"/></returns>
+        /// <remarks>
+        /// This function is different from most in that it involves drawing _output_ to the screen, rather than
+        /// drawing typed user input. It's still useful because if users want syntax-highlighted input, chances are they
+        /// also want syntax-highlighted output. It's sort of co-opting existing input functions for the purposes of output.
+        /// </remarks>
+        public static string RenderAnsiOutput(string text, IReadOnlyCollection<FormatSpan> formatting, int textWidth)
+        {
+            var rows = CellRenderer.ApplyColorToCharacters(formatting, text, textWidth);
+            var initialCursor = new ConsoleCoordinate(0, 0);
+            var finalCursor = new ConsoleCoordinate(rows.Length - 1, 0);
+            var output = IncrementalRendering.CalculateDiff(
+                previousScreen:  new Screen(textWidth, rows.Length, initialCursor),
+                currentScreen: new Screen(textWidth, rows.Length, finalCursor, new ScreenArea(initialCursor, rows, TruncateToScreenHeight: false)),
+                ansiCoordinate: initialCursor
+            );
+            return output;
+        }
     }
 
     /// <summary>
@@ -147,12 +184,25 @@ namespace PrettyPrompt
 
     /// <summary>
     /// Represents the user's input from the prompt.
-    /// If the user successfully submitted text, Success will be true and Text will be present.
-    /// If the user cancelled (via ctrl-c), Success will be false and Text will be an empty string.
+    /// If the user successfully submitted text, <paramref name="IsSuccess"/> will be true and <paramref name="Text"/> will contain the input.
+    /// If the user cancelled (via ctrl-c), <paramref name="IsSuccess"/> will be false and <paramref name="Text"/> will be an empty string.
     /// </summary>
     public record PromptResult(bool IsSuccess, string Text, bool IsHardEnter)
     {
         internal CancellationTokenSource CancellationTokenSource { get; set; }
+
+        /// <summary>
+        /// If your user presses ctrl-c while your application is processing the user's input, this CancellationToken will be
+        /// signalled (i.e. IsCancellationRequested will be set to true)
+        /// </summary>
         public CancellationToken CancellationToken => CancellationTokenSource?.Token ?? CancellationToken.None;
     }
+
+    /// <summary>
+    /// Represents the result of a user's key press, when they pressed a keybinding from <see cref="PromptCallbacks.KeyPressCallbacks"/>.
+    /// If the keybinding should submit the current prompt (e.g. so the consuming application can 
+    /// </summary>
+    /// <param name="Input">The current input on the prompt when the user pressed the keybinding</param>
+    /// <param name="Output">Any output the consuming application wants to display as a result of the keybinding</param>
+    public record KeyPressCallbackResult(string Input, string Output) : PromptResult(true, Input, false);
 }

--- a/src/PrettyPrompt/PromptCallbacks.cs
+++ b/src/PrettyPrompt/PromptCallbacks.cs
@@ -12,9 +12,54 @@ using PrettyPrompt.Highlighting;
 
 namespace PrettyPrompt
 {
+    /// <summary>
+    /// A callback your application can provide to autocomplete input text.
+    /// <seealso cref="PromptCallbacks.CompletionCallback"/>
+    /// </summary>
+    /// <param name="text">The user's input text</param>
+    /// <param name="caret">The index of the text caret in the input text</param>
+    /// <returns>A list of possible completions that will be displayed in the autocomplete menu.</returns>
     public delegate Task<IReadOnlyList<CompletionItem>> CompletionCallbackAsync(string text, int caret);
+
+    /// <summary>
+    /// A callback your application can provide to syntax-highlight input text.
+    /// <seealso cref="PromptCallbacks.HighlightCallback"/>
+    /// </summary>
+    /// <param name="text">The text to be highlighted</param>
+    /// <returns>A collection of formatting instructions</returns>
     public delegate Task<IReadOnlyCollection<FormatSpan>> HighlightCallbackAsync(string text);
-    public delegate Task KeyPressCallbackAsync(string text, int caret);
+
+    /// <summary>
+    /// A callback your application can provide to define custom behavior when a key is pressed.
+    /// <seealso cref="PromptCallbacks.KeyPressCallbacks"/>
+    /// </summary>
+    /// <param name="text">The user's input text</param>
+    /// <param name="caret">The index of the text caret in the input text</param>
+    /// <returns>
+    /// <list type="bullet">
+    /// <item>
+    /// If a non-null <see cref="KeyPressCallbackResult"/> is returned, the prompt will be submitted.
+    /// The <see cref="KeyPressCallbackResult"/> will be returned by the current
+    /// <see cref="Prompt.ReadLineAsync(string)"/> function.
+    /// </item>
+    /// <item>
+    /// If a null <see cref="KeyPressCallbackResult"/> is returned, then the user will remain on the
+    /// current prompt.
+    /// </item>
+    /// </list>
+    /// </returns>
+    public delegate Task<KeyPressCallbackResult?> KeyPressCallbackAsync(string text, int caret);
+
+    /// <summary>
+    /// A callback your application can provide to define whether pressing "Enter" should insert a
+    /// newline ("soft-enter") or if the prompt should be submitted instead.
+    /// current prompt, or insert a newline instead.
+    /// <seealso cref="PromptCallbacks.ForceSoftEnterCallback"/>
+    /// </summary>
+    /// <param name="text">The current input text on the prompt.</param>
+    /// <returns>
+    /// true if a newline should be inserted ("soft-enter") or false if the prompt should be submitted.
+    /// </returns>
     public delegate Task<bool> ForceSoftEnterCallbackAsync(string text);
 
     public class PromptCallbacks
@@ -22,18 +67,21 @@ namespace PrettyPrompt
         /// <summary>
         /// An optional delegate that provides autocompletion results
         /// </summary>
-        public CompletionCallbackAsync CompletionCallback { get; init; } = (_, _) => Task.FromResult<IReadOnlyList<CompletionItem>>(Array.Empty<CompletionItem>());
+        public CompletionCallbackAsync CompletionCallback { get; init; } =
+            (_, _) => Task.FromResult<IReadOnlyList<CompletionItem>>(Array.Empty<CompletionItem>());
 
         /// <summary>
         /// An optional delegate that controls syntax highlighting
         /// </summary>
-        public HighlightCallbackAsync HighlightCallback { get; init; } = _ => Task.FromResult<IReadOnlyCollection<FormatSpan>>(Array.Empty<FormatSpan>());
+        public HighlightCallbackAsync HighlightCallback { get; init; } =
+            _ => Task.FromResult<IReadOnlyCollection<FormatSpan>>(Array.Empty<FormatSpan>());
 
         /// <summary>
         /// An optional delegate that allows for intercepting the "Enter" key and causing it to
         /// insert a "soft enter" (newline) instead of submitting the prompt.
         /// </summary>
-        public ForceSoftEnterCallbackAsync ForceSoftEnterCallback { get; init; } = _ => Task.FromResult(false);
+        public ForceSoftEnterCallbackAsync ForceSoftEnterCallback { get; init; } =
+            _ => Task.FromResult(false);
 
         /// <summary>
         /// A dictionary of "(ConsoleModifiers, ConsoleKey)" to "Callback Functions"
@@ -41,15 +89,20 @@ namespace PrettyPrompt
         /// text and the caret position within the text. ConsoleModifiers can be omitted if not required.
         /// </summary>
         /// <example>
-        /// The following will invoke MyCallbackFn whenever Ctrl+F1 is pressed:
+        /// The following will invoke MyOtherCallbackFn whenever Ctrl+F1 is pressed:
         /// <code>
         /// KeyPressCallbacks =
         /// {
-        ///     [(ConsoleModifiers.Control, ConsoleKey.F1)] = MyCallbackFn
+        ///     [ConsoleKey.F1] = MyCallbackFn
+        ///     [(ConsoleModifiers.Control, ConsoleKey.F1)] = MyOtherCallbackFn
         /// }
         /// </code>
+        /// If the prompt should be submitted as a result of the user's key press, then a non-null <see cref="KeyPressCallbackResult"/> may
+        /// be returned from the <see cref="KeyPressCallbackAsync"/> function. If a null result is returned, then the user will remain on
+        /// the current input prompt.
         /// </example>
-        public Dictionary<object, KeyPressCallbackAsync> KeyPressCallbacks { get; init; } = new Dictionary<object, KeyPressCallbackAsync>();
+        public Dictionary<object, KeyPressCallbackAsync> KeyPressCallbacks { get; init; } =
+            new Dictionary<object, KeyPressCallbackAsync>();
     }
 }
 

--- a/src/PrettyPrompt/Rendering/Renderer.cs
+++ b/src/PrettyPrompt/Rendering/Renderer.cs
@@ -24,9 +24,9 @@ namespace PrettyPrompt
     /// This class mostly deals with generating Cells, which the <see cref="IncrementalRendering"/> class then processes
     /// to generate the minimal set of ANSI escape sequences to write to the screen.
     /// </summary>
-    class Renderer
+    internal class Renderer
     {
-        const int BOTTOM_PADDING = 6;
+        private const int BottomPadding = 6;
 
         private readonly IConsole console;
         private readonly string prompt;
@@ -51,12 +51,12 @@ namespace PrettyPrompt
         public void RenderPrompt()
         {
             // write some newlines to ensure we have enough room to render the completion pane.
-            console.Write(new string('\n', BOTTOM_PADDING) + MoveCursorUp(BOTTOM_PADDING) + MoveCursorToColumn(1) + Reset + prompt);
+            console.Write(new string('\n', BottomPadding) + MoveCursorUp(BottomPadding) + MoveCursorToColumn(1) + Reset + prompt);
         }
 
-        public async Task RenderOutput(CodePane codePane, CompletionPane completionPane, IReadOnlyCollection<FormatSpan> highlights, KeyPress key)
+        public async Task RenderOutput(PromptResult result, CodePane codePane, CompletionPane completionPane, IReadOnlyCollection<FormatSpan> highlights, KeyPress key)
         {
-            if (codePane.Result is not null)
+            if (result is not null)
             {
                 Write(
                     MoveCursorDown(codePane.Document.WordWrappedLines.Count - codePane.Document.Cursor.Row - 1)

--- a/tests/PrettyPrompt.Tests/OutputTests.cs
+++ b/tests/PrettyPrompt.Tests/OutputTests.cs
@@ -1,0 +1,49 @@
+﻿using PrettyPrompt.Highlighting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using static PrettyPrompt.Consoles.AnsiEscapeCodes;
+
+namespace PrettyPrompt.Tests
+{
+    public class OutputTests
+    {
+        [Fact]
+        public void RenderAnsiOutput_GivenFormat_AppliesAnsiEscapeSequences()
+        {
+            var output = Prompt.RenderAnsiOutput("here is some output", new[]
+            {
+                new FormatSpan(0, 4, new ConsoleFormat { Foreground = AnsiColor.Red }),
+                new FormatSpan(8, 4, new ConsoleFormat { Foreground = AnsiColor.Green }),
+            }, 100);
+
+            Assert.Equal(
+                Red + "here" + Reset + " is " + Green + "some" + Reset + " output" + MoveCursorLeft(19),
+                output
+            );
+        }
+
+        [Fact]
+        public void RenderAnsiOutput_GivenFormatAndWrapping_AppliesAnsiEscapeSequences()
+        {
+            var output = Prompt.RenderAnsiOutput("here is some output", new[]
+            {
+                new FormatSpan(0, 4, new ConsoleFormat { Foreground = AnsiColor.Red }),
+                new FormatSpan(8, 4, new ConsoleFormat { Foreground = AnsiColor.Green }),
+            }, 4);
+
+            Assert.Equal(
+                expected:
+                    Red + "here\n" + MoveCursorLeft(3) +
+                    Reset + " is \n" + MoveCursorLeft(3) +
+                    Green + "some\n" + MoveCursorLeft(3) +
+                    Reset + " out\n" + MoveCursorLeft(3) +
+                    "put" + MoveCursorLeft(3),
+                actual: output
+            );
+        }
+    }
+}

--- a/tests/PrettyPrompt.Tests/PromptTests.cs
+++ b/tests/PrettyPrompt.Tests/PromptTests.cs
@@ -254,7 +254,7 @@ namespace PrettyPrompt.Tests
             {
                 KeyPressCallbacks =
                 {
-                    [F1] = (inputArg, caretArg) => { input = inputArg; caret = caretArg; return Task.CompletedTask; }
+                    [F1] = (inputArg, caretArg) => { input = inputArg; caret = caretArg; return Task.FromResult<KeyPressCallbackResult>(null); }
                 }
             }, console: console);
 
@@ -262,6 +262,28 @@ namespace PrettyPrompt.Tests
 
             Assert.Equal("I like apple", input);
             Assert.Equal(2, caret);
+        }
+
+        [Fact]
+        public async Task ReadLine_KeyPressCallbackReturnsOutput_IsReturned()
+        {
+            var console = ConsoleStub.NewConsole();
+            console.StubInput($"I like apple{Control}{LeftArrow}{Control}{LeftArrow}{F2}{Enter}");
+
+            var callbackOutput = new KeyPressCallbackResult("", "Callback output!");
+            var prompt = new Prompt(callbacks: new PromptCallbacks
+            {
+                KeyPressCallbacks =
+                {
+                    [F2] = (inputArg, caretArg) => {
+                        return Task.FromResult(callbackOutput);
+                    }
+                }
+            }, console: console);
+
+            var result = await prompt.ReadLineAsync("> ");
+
+            Assert.Equal(callbackOutput, result);
         }
     }
 }


### PR DESCRIPTION
Previously, custom keybindings could only operate on the current prompt, and couldn't submit the prompt on behalf of the user. Now, by returning a non-null KeyPressCallbackResult, we can.

This is useful if we want keybindings that can evaluate the user's input in different ways than the default evaluation method.