### PR TITLE
Configure when completion window should open

### DIFF
--- a/src/PrettyPrompt/Prompt.cs
+++ b/src/PrettyPrompt/Prompt.cs
@@ -26,6 +26,7 @@ namespace PrettyPrompt
         private readonly CancellationManager cancellationManager;
 
         private readonly CompletionCallbackAsync completionCallback;
+        private readonly OpenCompletionWindowCallbackAsync shouldOpenCompletionWindow;
         private readonly ForceSoftEnterCallbackAsync detectSoftEnterCallback;
         private readonly Dictionary<object, KeyPressCallbackAsync> keyPressCallbacks;
         private readonly SyntaxHighlighter highlighter;
@@ -49,6 +50,7 @@ namespace PrettyPrompt
 
             callbacks ??= new PromptCallbacks();
             this.completionCallback = callbacks.CompletionCallback;
+            this.shouldOpenCompletionWindow = callbacks.OpenCompletionWindowCallback;
             this.detectSoftEnterCallback = callbacks.ForceSoftEnterCallback;
             this.keyPressCallbacks = callbacks.KeyPressCallbacks;
 
@@ -67,7 +69,7 @@ namespace PrettyPrompt
             codePane.MeasureConsole(console, prompt);
 
             // completion pane is the pop-up window that shows potential autocompletions.
-            var completionPane = new CompletionPane(codePane, completionCallback);
+            var completionPane = new CompletionPane(codePane, completionCallback, shouldOpenCompletionWindow);
 
             history.Track(codePane);
             cancellationManager.CaptureControlC();

--- a/src/PrettyPrompt/PromptCallbacks.cs
+++ b/src/PrettyPrompt/PromptCallbacks.cs
@@ -22,6 +22,21 @@ namespace PrettyPrompt
     public delegate Task<IReadOnlyList<CompletionItem>> CompletionCallbackAsync(string text, int caret);
 
     /// <summary>
+    /// A callback your application can provide to determine whether or not the completion window
+    /// should automatically open. If not specified, C# intellisense style behavior is used.
+    /// </summary>
+    /// <param name="text">The user's input text</param>
+    /// <param name="caret">The index of the text caret in the input text</param>
+    /// <returns>
+    /// An integer that represents if the completion window should open and the offset at which it should be anchored.
+    /// If the caret moves behind this anchor, the completion window will automatically close. For example:
+    /// Less than zero, the window does not open.
+    /// zero, the window opens and the completion window is anchored at the current index.
+    /// one, the window opens and the completion window is anchored at one character before the cursor.
+    /// </returns>
+    public delegate Task<int> OpenCompletionWindowCallbackAsync(string text, int caret);
+
+    /// <summary>
     /// A callback your application can provide to syntax-highlight input text.
     /// <seealso cref="PromptCallbacks.HighlightCallback"/>
     /// </summary>
@@ -69,6 +84,11 @@ namespace PrettyPrompt
         /// </summary>
         public CompletionCallbackAsync CompletionCallback { get; init; } =
             (_, _) => Task.FromResult<IReadOnlyList<CompletionItem>>(Array.Empty<CompletionItem>());
+
+        /// <summary>
+        /// An optional delegate that controls when the completion window should open.
+        /// </summary>
+        public OpenCompletionWindowCallbackAsync OpenCompletionWindowCallback { get; init; }
 
         /// <summary>
         /// An optional delegate that controls syntax highlighting


### PR DESCRIPTION
PrettyPrompt comes from CSharpRepl roots, so some of its behavior is specific to C#. This PR allows customization of when the completion window should open, which helps decouple it from C# style behavior.

It adds a new `PromptCallback.OpenCompletionWindowCallback` property; see the documentation on the delegate for more detail.

Example program with custom callback (for filepaths) available in commit https://github.com/waf/PrettyPrompt/commit/ada326d2fe36f5930bfdc21a034f319c2d9711c9