### PR TITLE
Possibility to format individual completions and its descriptions

### DIFF
--- a/src/PrettyPrompt/Completion/CompletionItem.cs
+++ b/src/PrettyPrompt/Completion/CompletionItem.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Threading.Tasks;
+using PrettyPrompt.Highlighting;
 
 namespace PrettyPrompt.Completion
 {
@@ -27,11 +28,11 @@ namespace PrettyPrompt.Completion
         /// <summary>
         /// This text will be displayed in the completion menu. If not specified, the replacement text will be used.
         /// </summary>
-        public string DisplayText { get; init; }
+        public FormattedString DisplayText { get; init; }
 
         /// <summary>
         /// This lazy task will be executed when the item is selected, to display the extended "tool tip" description to the right of the menu.
         /// </summary>
-        public Lazy<Task<string>> ExtendedDescription { get; init; }
+        public Lazy<Task<FormattedString>> ExtendedDescription { get; init; }
     }
 }

--- a/src/PrettyPrompt/Documents/WordWrapping.cs
+++ b/src/PrettyPrompt/Documents/WordWrapping.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using PrettyPrompt.Consoles;
+using PrettyPrompt.Highlighting;
 using PrettyPrompt.Rendering;
 
 namespace PrettyPrompt.Documents
@@ -37,7 +38,7 @@ namespace PrettyPrompt.Documents
             int textIndex = 0;
             foreach (ReadOnlyMemory<char> chunk in input.GetChunks())
             {
-                for(var i = 0; i < chunk.Span.Length; i++)
+                for (var i = 0; i < chunk.Span.Length; i++)
                 {
                     char character = chunk.Span[i];
                     line.Append(character);
@@ -79,46 +80,47 @@ namespace PrettyPrompt.Documents
         /// where possible, otherwise split by character if a single word is
         /// greater than maxLength.
         /// </summary>
-        public static List<string> WrapWords(string text, int maxLength)
+        public static List<FormattedString> WrapWords(FormattedString input, int maxLength)
         {
-            if (text.Length == 0)
+            if (input.Length == 0)
             {
-                return new List<string>();
+                return new List<FormattedString>();
             }
 
-            var lines = new List<string>();
-            foreach (var line in text.Split('\n'))
+            var lines = new List<FormattedString>();
+            foreach (var line in input.Split('\n'))
             {
-                var currentLine = new StringBuilder();
+                var currentLine = new FormattedStringBuilder();
                 int currentLineWidth = 0;
-                foreach (var currentWord in line.Split(' ').SelectMany(word => word.SplitIntoSubstrings(maxLength)))
+                foreach (var currentWord in line.Split(' ').SelectMany(word => word.SplitIntoChunks(maxLength)))
                 {
-                    var wordLength = UnicodeWidth.GetWidth(currentWord);
+                    var wordLength = currentWord.GetUnicodeWidth();
                     var wordWithSpaceLength = currentLineWidth == 0 ? wordLength : wordLength + 1;
 
-                    if (currentLineWidth > maxLength
-                        || currentLineWidth + wordWithSpaceLength > maxLength)
+                    if (currentLineWidth > maxLength ||
+                        currentLineWidth + wordWithSpaceLength > maxLength)
                     {
-                        lines.Add(currentLine.ToString());
+                        lines.Add(currentLine.ToFormattedString());
                         currentLine.Clear();
                         currentLineWidth = 0;
                     }
 
-                    if(currentLineWidth == 0)
+                    if (currentLineWidth == 0)
                     {
                         currentLine.Append(currentWord);
                         currentLineWidth += wordLength;
                     }
                     else
                     {
-                        currentLine.Append(" " + currentWord);
+                        currentLine.Append(" ");
+                        currentLine.Append(currentWord);
                         currentLineWidth += wordLength + 1;
                     }
                 }
 
                 if (currentLineWidth > 0)
                 {
-                    lines.Add(currentLine.ToString());
+                    lines.Add(currentLine.ToFormattedString());
                 }
             }
 

--- a/src/PrettyPrompt/Extensions.cs
+++ b/src/PrettyPrompt/Extensions.cs
@@ -4,11 +4,8 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #endregion
 
-using PrettyPrompt.Rendering;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.Text;
 
 namespace PrettyPrompt
 {
@@ -18,46 +15,6 @@ namespace PrettyPrompt
             Environment.NewLine == "\n"
                 ? text
                 : text.Replace("\n", Environment.NewLine);
-
-        public static IEnumerable<string> EnumerateTextElements(this string text)
-        {
-            var enumerator = StringInfo.GetTextElementEnumerator(text);
-            while(enumerator.MoveNext())
-            {
-                yield return enumerator.GetTextElement();
-            }
-        }
-
-        public static IEnumerable<string> SplitIntoSubstrings(this string str, int maxChunkSize)
-        {
-            var stringWidth = UnicodeWidth.GetWidth(str);
-            if (stringWidth <= maxChunkSize)
-            {
-                yield return str;
-                yield break;
-            }
-
-            var buffer = new StringBuilder();
-
-            int width = 0;
-            foreach (var c in str)
-            {
-                var cWidth = UnicodeWidth.GetWidth(c);
-                if(width + cWidth > maxChunkSize)
-                {
-                    yield return buffer.ToString();
-                    buffer.Clear();
-                    width = 0;
-                }
-                width += cWidth;
-                buffer.Append(c);
-            }
-
-            if(buffer.Length > 0)
-            {
-                yield return buffer.ToString();
-            }
-        }
 
         /// <summary>
         /// Like <see cref="System.Linq.Enumerable.Zip{TFirst, TSecond}(IEnumerable{TFirst}, IEnumerable{TSecond})"/>,

--- a/src/PrettyPrompt/Highlighting/ConsoleFormat.cs
+++ b/src/PrettyPrompt/Highlighting/ConsoleFormat.cs
@@ -4,18 +4,85 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #endregion
 
+using System;
+
 namespace PrettyPrompt.Highlighting
 {
-    public sealed record FormatSpan(
-        int Start,
-        int Length,
-        ConsoleFormat Formatting
-    );
+    public sealed record FormatSpan
+    {
+        public static readonly FormatSpan Empty = new(0, 0, ConsoleFormat.None);
+
+        public int Start { get; }
+        public int Length { get; }
+        public ConsoleFormat Formatting { get; }
+
+        public FormatSpan(
+           int start,
+           int length,
+           ConsoleFormat formatting)
+        {
+            if (start < 0) throw new ArgumentException("Cannot be negative.", nameof(start));
+            if (length < 0) throw new ArgumentException("Cannot be negative.", nameof(length));
+
+            Start = start;
+            Length = length;
+            Formatting = formatting;
+        }
+
+        public static FormatSpan FromBounds(int start, int end, ConsoleFormat formatting) => new FormatSpan(start, end - start, formatting);
+
+        /// <summary>
+        /// Determines whether the position lies within the span.
+        /// </summary>
+        public bool Contains(int index) => index >= Start && index < Start + Length;
+
+        /// <summary>
+        /// The end of the span. The span is open-ended on the right side, which is to say that Start + Length = End.
+        /// </summary>
+        public int End => Start + Length;
+
+        /// <summary>
+        /// Creates new span translated by some offset.
+        /// </summary>
+        public FormatSpan Offset(int offset) => new(Start + offset, Length, Formatting);
+
+        /// <summary>
+        /// Creates new span with new length.
+        /// </summary>
+        public FormatSpan WithLength(int length) => new(Start, length, Formatting);
+
+        /// <summary>
+        /// Determines whether span overlaps this span. Two spans are considered to overlap if they have positions in common and neither is empty. Empty spans do not overlap with any other span.
+        /// </summary>
+        public bool OverlapsWith(FormatSpan span) => OverlapsWith(span.Start, span.Length);
+
+        /// <summary>
+        /// Determines whether span overlaps this span. Two spans are considered to overlap if they have positions in common and neither is empty. Empty spans do not overlap with any other span.
+        /// </summary>
+        public bool OverlapsWith(int start, int length) => Math.Max(Start, start) < Math.Min(End, start + length);
+
+        /// <summary>
+        /// Returns the overlap with the given span, or null if there is no overlap.
+        /// </summary>
+        public FormatSpan Overlap(int start, int length)
+        {
+            int resultStart = Math.Max(Start, start);
+            int resultEnd = Math.Min(End, start + length);
+            if (resultStart < resultEnd)
+            {
+                return new FormatSpan(FromBounds(resultStart, resultEnd, Formatting));
+            }
+            return null;
+        }
+    }
 
     public sealed record ConsoleFormat(
         AnsiColor Foreground = null,
         AnsiColor Background = null,
         bool Bold = false,
         bool Underline = false,
-        bool Inverted = false);
+        bool Inverted = false)
+    {
+        public static readonly ConsoleFormat None = new();
+    }
 }

--- a/src/PrettyPrompt/Highlighting/FormattedString.cs
+++ b/src/PrettyPrompt/Highlighting/FormattedString.cs
@@ -317,10 +317,6 @@ namespace PrettyPrompt.Highlighting
                     else
                     {
                         formatting = ConsoleFormat.None;
-                        if (textIndex >= span.End)
-                        {
-                            formatIndex++;
-                        }
                     }
                 }
                 else
@@ -329,7 +325,13 @@ namespace PrettyPrompt.Highlighting
                 }
 
                 yield return (element, formatting);
+
                 textIndex += element.Length;
+                if (formatIndex < formatSpans.Length &&
+                    textIndex >= formatSpans[formatIndex].End)
+                {
+                    formatIndex++;
+                }
             }
         }
 

--- a/src/PrettyPrompt/Highlighting/FormattedString.cs
+++ b/src/PrettyPrompt/Highlighting/FormattedString.cs
@@ -1,0 +1,378 @@
+﻿#region License Header
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using PrettyPrompt.Rendering;
+
+namespace PrettyPrompt.Highlighting
+{
+    /// <summary>
+    /// Represents text with associated non-overlapping formating spans.
+    /// </summary>
+    public struct FormattedString : IEquatable<FormattedString>
+    {
+        public static FormattedString Empty => string.Empty;
+
+        public string Text { get; private set; }
+        private readonly FormatSpan[] formatSpans;
+
+        public IReadOnlyList<FormatSpan> FormatSpans => formatSpans ?? Array.Empty<FormatSpan>();
+        public int Length => Text?.Length ?? 0;
+
+        private string TextOrEmpty => Text ?? "";
+        private FormatSpan[] FormatSpansOrEmpty => formatSpans ?? Array.Empty<FormatSpan>();
+
+        public FormattedString(string text, IEnumerable<FormatSpan> formatSpans)
+            : this(text, formatSpans?.ToArray())
+        { }
+
+        public FormattedString(string text, params FormatSpan[] formatSpans)
+        {
+            Text = text;
+            if ((formatSpans?.Length ?? 0) == 0)
+            {
+                this.formatSpans = Array.Empty<FormatSpan>();
+            }
+            else
+            {
+                this.formatSpans = formatSpans.Where(s => s.Length > 0).OrderBy(s => s.Start).ToArray();
+                CheckFormatSpans();
+            }
+        }
+
+        public FormattedString(string text, ConsoleFormat formatting)
+            : this(text, new FormatSpan(0, text.Length, formatting))
+        {
+        }
+
+        public static implicit operator FormattedString(string text) => new(text);
+
+        public static FormattedString operator +(FormattedString left, FormattedString right)
+        {
+            var resultText = left.TextOrEmpty + right.TextOrEmpty;
+
+            var leftFormatSpans = left.FormatSpansOrEmpty;
+            var rightFormatSpans = right.FormatSpansOrEmpty;
+            var resultFormatSpans = new FormatSpan[leftFormatSpans.Length + rightFormatSpans.Length];
+            leftFormatSpans.AsSpan().CopyTo(resultFormatSpans);
+            for (int i = 0; i < rightFormatSpans.Length; i++)
+            {
+                resultFormatSpans[leftFormatSpans.Length + i] = rightFormatSpans[i].Offset(left.TextOrEmpty.Length);
+            }
+
+            return new FormattedString(resultText, resultFormatSpans);
+        }
+
+        public int GetUnicodeWidth() => UnicodeWidth.GetWidth(Text);
+
+        /// <summary>
+        /// Removes all leading and trailing white-space characters from the current string.
+        /// </summary>
+        public FormattedString Trim()
+        {
+            if (Text is null) return Empty;
+            if (FormatSpansOrEmpty.Length == 0) return Text.Trim();
+
+            var trimedCharsFromLeft = Text.Length - Text.AsSpan().TrimStart().Length;
+            if (trimedCharsFromLeft == Text.Length) return Empty;
+
+            var trimedCharsFromRight = Text.Length - Text.AsSpan().TrimEnd().Length;
+            return Substring(trimedCharsFromLeft, Text.Length - trimedCharsFromLeft - trimedCharsFromRight);
+        }
+
+        /// <summary>
+        /// Retrieves a substring from this instance. The substring starts at a specified character position and has a specified length.
+        /// </summary>
+        public FormattedString Substring(int startIndex, int length)
+        {
+            if (Text is null) return Empty;
+
+            var substring = Text.Substring(startIndex, length);
+            if (FormatSpansOrEmpty.Length == 0) return substring;
+
+            var resultFormatSpans = new List<FormatSpan>(formatSpans.Length);
+            foreach (var formatSpan in formatSpans)
+            {
+                var newSpan = formatSpan.Overlap(startIndex, length);
+                if (newSpan is not null)
+                {
+                    resultFormatSpans.Add(newSpan.Offset(-startIndex));
+                }
+            }
+
+            return new(substring, resultFormatSpans);
+        }
+
+        /// <summary>
+        /// Returns a new string in which all occurrences of a specified string in the current instance are replaced with another specified string.
+        /// </summary>
+        public FormattedString Replace(string oldValue, string newValue)
+        {
+            if (Text is null) return Empty;
+            if (FormatSpansOrEmpty.Length == 0) return Text.Replace(oldValue, newValue);
+
+            var text = Text.AsSpan();
+            int currentOffsetInPartialyReplacedText = 0;
+
+            var sb = new StringBuilder();
+            var formatSpans = this.formatSpans.ToArray();
+            int formatIndex = 0;
+            while (true)
+            {
+                var replaceIndex = text.IndexOf(oldValue);
+                if (replaceIndex < 0) break;
+
+                sb.Append(text.Slice(0, replaceIndex));
+                sb.Append(newValue);
+
+                var replaceIndexInPartialyReplacedText = replaceIndex + currentOffsetInPartialyReplacedText;
+                for (int i = formatIndex; i < formatSpans.Length; i++)
+                {
+                    ref var formatSpan = ref formatSpans[i];
+                    if (replaceIndexInPartialyReplacedText >= formatSpan.End)
+                    {
+                        //replace happens after current span, so we don't care about it anymore
+                        Debug.Assert(i == formatIndex);
+                        formatIndex++;
+                    }
+                    else if (formatSpan.OverlapsWith(start: replaceIndexInPartialyReplacedText, length: oldValue.Length))
+                    {
+                        //replace overlaps with current span
+                        if (replaceIndexInPartialyReplacedText >= formatSpan.Start && oldValue.Length >= formatSpan.Length)
+                        {
+                            //replace happens inside current span, so we just make the span shorter
+                            formatSpan = formatSpan.WithLength(formatSpan.Length - oldValue.Length + newValue.Length);
+                        }
+                        else
+                        {
+                            //complex ovelap - we cannot decide what to do - throw the span away
+                            formatSpan = FormatSpan.Empty;
+                        }
+                    }
+                    else
+                    {
+                        //replace happens before current span, so we just need to translate the whole span
+                        formatSpan = formatSpan.Offset(newValue.Length - oldValue.Length);
+                    }
+                }
+
+                text = text.Slice(replaceIndex + oldValue.Length);
+                currentOffsetInPartialyReplacedText += replaceIndex + newValue.Length;
+            }
+
+            sb.Append(text);
+
+            return new FormattedString(sb.ToString(), formatSpans);
+        }
+
+        /// <summary>
+        /// Splits a string into substrings based on the provided character separator.
+        /// </summary>
+        public IEnumerable<FormattedString> Split(char separator)
+        {
+            var text = Text;
+            if (text is null) yield break;
+
+            if (FormatSpansOrEmpty.Length == 0)
+            {
+                foreach (var part in text.Split(separator))
+                {
+                    yield return part;
+                }
+            }
+            else
+            {
+                int partStart = 0;
+                var formattingList = new List<FormatSpan>(formatSpans.Length);
+                int usedFormattingCount = 0;
+                int previousFormattingCharsUsed = 0;
+                while (partStart < text.Length)
+                {
+                    int partLength = 0;
+                    for (int i = partStart; i < text.Length; i++, partLength++)
+                    {
+                        if (text[i] == separator) break;
+                    }
+
+                    GenerateFormattingsForPart(partStart, partLength, partSeparatorLength: 1, ref usedFormattingCount, ref previousFormattingCharsUsed, formattingList);
+
+                    yield return new FormattedString(text.AsSpan(partStart, partLength).ToString(), formattingList);
+                    partStart += partLength + 1; //+1 to skip separator
+                }
+            }
+        }
+
+        public IEnumerable<FormattedString> SplitIntoChunks(int chunkSize)
+        {
+            if (chunkSize < 1) throw new ArgumentOutOfRangeException(nameof(chunkSize), "has to be >= 1");
+
+            var text = Text;
+            if (text is null) yield break;
+
+            var stringWidth = UnicodeWidth.GetWidth(Text);
+            if (stringWidth <= chunkSize)
+            {
+                yield return this;
+                yield break;
+            }
+
+            int partStart = 0;
+            var formattingList = new List<FormatSpan>(formatSpans.Length);
+            int usedFormattingCount = 0;
+            int previousFormattingCharsUsed = 0;
+            while (partStart < text.Length)
+            {
+                int partLength = 0;
+                for (int i = partStart, partWidth = 0; i < text.Length; i++, partLength++)
+                {
+                    var cWidth = UnicodeWidth.GetWidth(text[i]);
+                    partWidth += cWidth;
+                    if (partWidth > chunkSize) break;
+                }
+
+                GenerateFormattingsForPart(partStart, partLength, partSeparatorLength: 0, ref usedFormattingCount, ref previousFormattingCharsUsed, formattingList);
+
+                yield return new FormattedString(text.AsSpan(partStart, partLength).ToString(), formattingList);
+                partStart += partLength;
+            }
+        }
+
+        private void GenerateFormattingsForPart(
+            int partStart,
+            int partLength,
+            int partSeparatorLength,
+            ref int usedFormattingCount,
+            ref int previousFormattingCharsUsed,
+            List<FormatSpan> formattingList)
+        {
+            formattingList.Clear();
+
+            var partEnd = partStart + partLength;
+            for (int i = usedFormattingCount; i < formatSpans.Length; i++)
+            {
+                var formatting = formatSpans[i];
+                if (formatting.Start >= partEnd)
+                {
+                    //no more formattings for this part
+                    break;
+                }
+
+                Debug.Assert(previousFormattingCharsUsed < formatting.Length);
+
+                if (formatting.End <= partStart)
+                {
+                    //formatting ended before this part
+                    previousFormattingCharsUsed = 0;
+                    usedFormattingCount++;
+                    continue;
+                }
+
+                var offset = -Math.Min(formatting.Start, partStart);
+                var newFormatting = formatting
+                    .Offset(offset) //has to be relative to strat of current part
+                    .WithLength(formatting.Length - previousFormattingCharsUsed) //some chars could be already used by previous parts
+                    .Overlap(0, partLength);
+
+                Debug.Assert(newFormatting is not null, "formatting has to overlap due to prior conditions");
+                formattingList.Add(newFormatting);
+
+                if (formatting.End <= partEnd + partSeparatorLength)
+                {
+                    //formatting cannot affect next part
+                    previousFormattingCharsUsed = 0;
+                    usedFormattingCount++;
+                }
+                else
+                {
+                    previousFormattingCharsUsed += newFormatting.Length + partSeparatorLength;
+                }
+            }
+        }
+
+        public IEnumerable<(string Element, ConsoleFormat Formatting)> EnumerateTextElements()
+        {
+            var enumerator = StringInfo.GetTextElementEnumerator(TextOrEmpty);
+            int textIndex = 0;
+            int formatIndex = 0;
+            while (enumerator.MoveNext())
+            {
+                var element = enumerator.GetTextElement();
+
+                ConsoleFormat formatting;
+                if (formatIndex < formatSpans.Length)
+                {
+                    var span = formatSpans[formatIndex];
+                    if (span.Contains(textIndex))
+                    {
+                        formatting = span.Formatting;
+                    }
+                    else
+                    {
+                        formatting = ConsoleFormat.None;
+                        if (textIndex >= span.End)
+                        {
+                            formatIndex++;
+                        }
+                    }
+                }
+                else
+                {
+                    formatting = ConsoleFormat.None;
+                }
+
+                yield return (element, formatting);
+                textIndex += element.Length;
+            }
+        }
+
+        private void CheckFormatSpans()
+        {
+            var textLen = Length;
+            if (textLen == 0)
+            {
+                if (formatSpans.Length != 0) throw new ArgumentException("There is no text to be formatted.", nameof(formatSpans));
+            }
+            else
+            {
+                for (int i = 0; i < formatSpans.Length; i++)
+                {
+                    var span = formatSpans[i];
+                    if (span.Start >= textLen) throw new ArgumentException("Span start cannot be larger than text length.", nameof(formatSpans));
+                    if (span.Start + span.Length > textLen) throw new ArgumentException("Span end cannot be outside of text.", nameof(formatSpans));
+
+                    if (i > 0)
+                    {
+                        var previousSpan = formatSpans[i - 1];
+                        if (span.Start < previousSpan.End) throw new ArgumentException("Spans cannot overlap.", nameof(formatSpans));
+                    }
+                }
+            }
+        }
+
+        public bool Equals(FormattedString other)
+        {
+            if (Text != other.Text) return false;
+            if (FormatSpans.Count != other.FormatSpans.Count) return false;
+            for (int i = 0; i < FormatSpans.Count; i++)
+            {
+                if (FormatSpans[i] != other.FormatSpans[i]) return false;
+            }
+            return true;
+        }
+
+        public override bool Equals(object obj) => obj is FormattedString other && Equals(other);
+        public override int GetHashCode() => string.GetHashCode(Text);
+        public override string ToString() => Text;
+
+        public static bool operator ==(FormattedString left, FormattedString right) => left.Equals(right);
+        public static bool operator !=(FormattedString left, FormattedString right) => !(left == right);
+    }
+}

--- a/src/PrettyPrompt/Highlighting/FormattedStringBuilder.cs
+++ b/src/PrettyPrompt/Highlighting/FormattedStringBuilder.cs
@@ -1,0 +1,47 @@
+﻿#region License Header
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#endregion
+
+using System.Collections.Generic;
+using System.Text;
+
+namespace PrettyPrompt.Highlighting
+{
+    public sealed class FormattedStringBuilder
+    {
+        private readonly StringBuilder stringBuilder = new();
+        private readonly List<FormatSpan> formatSpans = new();
+
+        public int Length => stringBuilder.Length;
+
+        public FormattedStringBuilder Append(FormattedString text)
+        {
+            foreach (var span in text.FormatSpans)
+            {
+                formatSpans.Add(span.Offset(stringBuilder.Length));
+            }
+            stringBuilder.Append(text.Text);
+            return this;
+        }
+
+        public FormattedStringBuilder Append(string text)
+        {
+            stringBuilder.Append(text);
+            return this;
+        }
+
+        public FormattedStringBuilder Append(string text, params FormatSpan[] formatSpans) 
+            => Append(new FormattedString(text, formatSpans));
+
+        public void Clear()
+        {
+            stringBuilder.Clear();
+            formatSpans.Clear();
+        }
+
+        public FormattedString ToFormattedString()
+            => new(stringBuilder.ToString(), formatSpans);
+    }
+}

--- a/src/PrettyPrompt/Rendering/Cell.cs
+++ b/src/PrettyPrompt/Rendering/Cell.cs
@@ -57,17 +57,17 @@ namespace PrettyPrompt
         }
 
         public static List<Cell> FromText(string text, ConsoleFormat formatting)
+            => FromText(new FormattedString(text, formatting));
+
+        public static List<Cell> FromText(FormattedString formattedString)
         {
             // note, this method is fairly hot, please profile when making changes to it.
-            var enumerator = StringInfo.GetTextElementEnumerator(text);
-            var cells = new List<Cell>(text.Length);
-
-            while(enumerator.MoveNext())
+            var cells = new List<Cell>(formattedString.Length);
+            foreach (var (element, formatting) in formattedString.EnumerateTextElements())
             {
-                var element = enumerator.GetTextElement();
                 var elementWidth = UnicodeWidth.GetWidth(element);
                 cells.Add(new Cell(element, formatting, elementWidth));
-                if(elementWidth > 1)
+                if (elementWidth > 1)
                 {
                     cells.AddRange(
                         Enumerable.Repeat(

--- a/tests/PrettyPrompt.Tests/CompletionTestData.cs
+++ b/tests/PrettyPrompt.Tests/CompletionTestData.cs
@@ -5,6 +5,7 @@
 #endregion
 
 using PrettyPrompt.Completion;
+using PrettyPrompt.Highlighting;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -36,7 +37,7 @@ namespace PrettyPrompt.Tests
                         StartIndex = previousWordStart + 1,
                         ReplacementText = c,
                         DisplayText = i % 2 == 0 ? c : null, // display text is optional, ReplacementText should be used when this is null.
-                        ExtendedDescription = new Lazy<Task<string>>(() => Task.FromResult("a vivid description of " + c))
+                        ExtendedDescription = new Lazy<Task<FormattedString>>(() => Task.FromResult<FormattedString>("a vivid description of " + c))
                     })
                     .ToArray()
             );

--- a/tests/PrettyPrompt.Tests/FormattedStringTests.cs
+++ b/tests/PrettyPrompt.Tests/FormattedStringTests.cs
@@ -1,0 +1,263 @@
+﻿using System.Linq;
+using PrettyPrompt.Highlighting;
+using Xunit;
+
+namespace PrettyPrompt.Tests
+{
+    public class FormattedStringTests
+    {
+        private static readonly ConsoleFormat Red = new(Foreground: AnsiColor.Red);
+        private static readonly ConsoleFormat Green = new(Foreground: AnsiColor.Green);
+        private static readonly ConsoleFormat Yellow = new(Foreground: AnsiColor.Yellow);
+
+        [Fact]
+        public void Concatenation_PreservesFormatting()
+        {
+            Assert.Equal(
+                FormattedString.Empty,
+                FormattedString.Empty + FormattedString.Empty);
+
+
+            var left = new FormattedString("lorem ipsum red sit amet ");
+            var right = new FormattedString("lorem green dolor sit amet");
+
+            Assert.Equal(
+                new FormattedString("lorem ipsum red sit amet lorem green dolor sit amet"),
+                left + right);
+
+
+            left = new FormattedString("lorem ipsum red sit amet ", new FormatSpan(12, 3, Red));
+            right = new FormattedString("lorem green dolor sit amet", new FormatSpan(6, 5, Green));
+
+            Assert.Equal(
+                new FormattedString(
+                    "lorem ipsum red sit amet lorem green dolor sit amet",
+                    new FormatSpan(12, 3, Red),
+                    new FormatSpan(31, 5, Green)),
+                left + right);
+        }
+
+        [Fact]
+        public void Trim_PreservesFormatting()
+        {
+            var value = FormattedString.Empty;
+            Assert.Equal(
+                FormattedString.Empty,
+                value.Trim());
+
+
+            value = new FormattedString("  lorem ipsum red sit amet     ", new FormatSpan(15, 3, Red));
+            Assert.Equal(
+                new FormattedString("lorem ipsum red sit amet", new FormatSpan(13, 3, Red)),
+                value.Trim());
+
+
+            value = new FormattedString("     ", new FormatSpan(1, 3, Red));
+            Assert.Equal(
+                FormattedString.Empty,
+                value.Trim());
+
+
+            value = new FormattedString("red", new FormatSpan(0, 3, Red));
+            Assert.Equal(
+                value,
+                value.Trim());
+        }
+
+        [Fact]
+        public void Trim_FormatOverTrimmedArea_PreservesFormatting()
+        {
+            var value = new FormattedString("  lorem     ", new FormatSpan(0, 12, Red));
+            Assert.Equal(
+                new FormattedString("lorem", new FormatSpan(0, 5, Red)),
+                value.Trim());
+
+
+            value = new FormattedString("  lorem     ", new FormatSpan(0, 1, Red), new FormatSpan(8, 2, Green));
+            Assert.Equal(
+                "lorem",
+                value.Trim());
+
+
+            value = new FormattedString("  lorem     ", new FormatSpan(0, 3, Red), new FormatSpan(6, 2, Green));
+            Assert.Equal(
+                new FormattedString("lorem", new FormatSpan(0, 1, Red), new FormatSpan(4, 1, Green)),
+                value.Trim());
+        }
+
+        [Fact]
+        public void Substring_PreservesFormatting()
+        {
+            var value = FormattedString.Empty;
+            Assert.Equal(
+                FormattedString.Empty,
+                value.Substring(0, 0));
+
+
+            value = new FormattedString("  lorem ipsum red sit amet     ", new FormatSpan(15, 3, Red));
+            Assert.Equal(
+                new FormattedString("lorem ipsum red sit amet", new FormatSpan(13, 3, Red)),
+                value.Trim());
+
+
+            value = new FormattedString("     ", new FormatSpan(1, 3, Red));
+            Assert.Equal(
+                FormattedString.Empty,
+                value.Trim());
+
+
+            value = new FormattedString("red", new FormatSpan(0, 3, Red));
+            Assert.Equal(
+                value,
+                value.Trim());
+        }
+
+        [Fact]
+        public void Substring_FormatOverTrimmedArea_PreservesFormatting()
+        {
+            var value = new FormattedString("  lorem     ", new FormatSpan(0, 12, Red));
+            Assert.Equal(
+                new FormattedString("lorem", new FormatSpan(0, 5, Red)),
+                value.Substring(2, 5));
+
+
+            value = new FormattedString("  lorem     ", new FormatSpan(0, 1, Red), new FormatSpan(8, 2, Green));
+            Assert.Equal(
+                "lorem",
+                value.Substring(2, 5));
+
+
+            value = new FormattedString("  lorem     ", new FormatSpan(0, 3, Red), new FormatSpan(6, 2, Green));
+            Assert.Equal(
+                new FormattedString("lorem", new FormatSpan(0, 1, Red), new FormatSpan(4, 1, Green)),
+                value.Substring(2, 5));
+        }
+
+        [Fact]
+        public void ReplaceNonFormatted_PreservesFormatting()
+        {
+            var value = FormattedString.Empty;
+            Assert.Equal(
+                FormattedString.Empty,
+                value.Replace("ipsum", "XY"));
+
+
+            value = new FormattedString("lorem ipsum red sit amet", new FormatSpan(12, 3, Red));
+            Assert.Equal(
+                new FormattedString("lorem XY red sit amet", new FormatSpan(9, 3, Red)),
+                value.Replace("ipsum", "XY"));
+
+
+            value = new FormattedString("lorem ipsumipsum red sit amet", new FormatSpan(17, 3, Red));
+
+            Assert.Equal(
+                new FormattedString("lorem XYXY red sit amet", new FormatSpan(11, 3, Red)),
+                value.Replace("ipsum", "XY"));
+
+            Assert.Equal(
+                new FormattedString("lorem  red sit amet", new FormatSpan(7, 3, Red)),
+                value.Replace("ipsum", ""));
+        }
+
+        [Fact]
+        public void ReplaceFormatted_PreservesFormatting()
+        {
+            var value = new FormattedString("lorem redredred ipsum", new FormatSpan(6, 3, Red), new FormatSpan(9, 3, Red), new FormatSpan(12, 3, Red));
+
+            Assert.Equal(
+                new FormattedString("lorem XYXYXY ipsum", new FormatSpan(6, 2, Red), new FormatSpan(8, 2, Red), new FormatSpan(10, 2, Red)),
+                value.Replace("red", "XY"));
+
+            Assert.Equal(
+                new FormattedString("lorem  ipsum"),
+                value.Replace("red", ""));
+
+            Assert.Equal(
+                new FormattedString("lo XY redred ipsum", new FormatSpan(6, 3, Red), new FormatSpan(9, 3, Red)),
+                value.Replace("rem red", " XY "));
+
+            Assert.Equal(
+                new FormattedString("loredred ipsum", new FormatSpan(2, 3, Red), new FormatSpan(5, 3, Red)),
+                value.Replace("rem red", ""));
+        }
+
+        [Fact]
+        public void Split_PreservesFormatting()
+        {
+            var value = FormattedString.Empty;
+            var parts = value.Split('_').ToArray();
+            Assert.Single(parts);
+            Assert.Equal(0, parts[0].Length);
+
+
+            value = new FormattedString("lorem red_ipsum green_dolor sit red", new FormatSpan(6, 3, Red), new FormatSpan(16, 5, Green), new FormatSpan(32, 3, Red));
+            parts = value.Split('_').ToArray();
+            Assert.Equal(3, parts.Length);
+            Assert.Equal(new FormattedString("lorem red", new FormatSpan(6, 3, Red)), parts[0]);
+            Assert.Equal(new FormattedString("ipsum green", new FormatSpan(6, 5, Green)), parts[1]);
+            Assert.Equal(new FormattedString("dolor sit red", new FormatSpan(10, 3, Red)), parts[2]);
+        }
+
+        [Fact]
+        public void Split_FormattingOverMultipleParts_PreservesFormatting()
+        {
+            var value = new FormattedString("lorem r_ee_ddd ipsum", new FormatSpan(6, 8, Red));
+
+            var parts = value.Split('_').ToArray();
+            Assert.Equal(3, parts.Length);
+            Assert.Equal(new FormattedString("lorem r", new FormatSpan(6, 1, Red)), parts[0]);
+            Assert.Equal(new FormattedString("ee", new FormatSpan(0, 2, Red)), parts[1]);
+            Assert.Equal(new FormattedString("ddd ipsum", new FormatSpan(0, 3, Red)), parts[2]);
+        }
+
+        [Fact]
+        public void Split_FormattingOverSeparator_PreservesFormatting()
+        {
+            var value = new FormattedString("a b", new FormatSpan(1, 1, Red));
+            var parts = value.Split(' ').ToArray();
+            Assert.Equal(2, parts.Length);
+            Assert.Equal("a", parts[0]);
+            Assert.Equal("b", parts[1]);
+
+
+            value = new FormattedString("red yellow", new FormatSpan(0, 4, Red), new FormatSpan(4, 6, Yellow));
+            parts = value.Split(' ').ToArray();
+            Assert.Equal(2, parts.Length);
+            Assert.Equal(new FormattedString("red", new FormatSpan(0, 3, Red)), parts[0]);
+            Assert.Equal(new FormattedString("yellow", new FormatSpan(0, 6, Yellow)), parts[1]);
+
+
+            value = new FormattedString("red (yellow ) green", new FormatSpan(0, 5, Red), new FormatSpan(5, 6, Yellow), new FormatSpan(12, 7, Green));
+            parts = value.Split(' ').ToArray();
+            Assert.Equal(4, parts.Length);
+            Assert.Equal(new FormattedString("red", new FormatSpan(0, 3, Red)), parts[0]);
+            Assert.Equal(new FormattedString("(yellow", new FormatSpan(0, 1, Red), new FormatSpan(1, 6, Yellow)), parts[1]);
+            Assert.Equal(new FormattedString(")", new FormatSpan(0, 1, Green)), parts[2]);
+            Assert.Equal(new FormattedString("green", new FormatSpan(0, 5, Green)), parts[3]);
+        }
+
+        [Fact]
+        public void SplitIntoChunks_PreservesFormatting()
+        {
+            var value = new FormattedString("lorem red   ipsum green dolor red", new FormatSpan(6, 3, Red), new FormatSpan(18, 5, Green), new FormatSpan(30, 3, Red));
+
+            var chunks = value.SplitIntoChunks(chunkSize: 12).ToArray();
+            Assert.Equal(3, chunks.Length);
+            Assert.Equal(new FormattedString("lorem red   ", new FormatSpan(6, 3, Red)), chunks[0]);
+            Assert.Equal(new FormattedString("ipsum green ", new FormatSpan(6, 5, Green)), chunks[1]);
+            Assert.Equal(new FormattedString("dolor red", new FormatSpan(6, 3, Red)), chunks[2]);
+        }
+
+        [Fact]
+        public void SplitIntoChunks_FormattingOverMultipleChunks_PreservesFormatting()
+        {
+            var value = new FormattedString("lorem reeeee ddd sit", new FormatSpan(6, 10, Red));
+
+            var chunks = value.SplitIntoChunks(chunkSize: 7).ToArray();
+            Assert.Equal(3, chunks.Length);
+            Assert.Equal(new FormattedString("lorem r", new FormatSpan(6, 1, Red)), chunks[0]);
+            Assert.Equal(new FormattedString("eeeee d", new FormatSpan(0, 7, Red)), chunks[1]);
+            Assert.Equal(new FormattedString("dd sit", new FormatSpan(0, 2, Red)), chunks[2]);
+        }
+    }
+}

--- a/tests/PrettyPrompt.Tests/FormattedStringTests.cs
+++ b/tests/PrettyPrompt.Tests/FormattedStringTests.cs
@@ -259,5 +259,39 @@ namespace PrettyPrompt.Tests
             Assert.Equal(new FormattedString("eeeee d", new FormatSpan(0, 7, Red)), chunks[1]);
             Assert.Equal(new FormattedString("dd sit", new FormatSpan(0, 2, Red)), chunks[2]);
         }
+
+        [Fact]
+        public void EnumerateTextElements_PreservesFormatting()
+        {
+            var value = new FormattedString(
+                "abc",
+                new FormatSpan(0, 1, Red),
+                new FormatSpan(1, 1, Green),
+                new FormatSpan(2, 1, Yellow));
+
+            var elements = value.EnumerateTextElements().ToArray();
+            Assert.Equal(3, elements.Length);
+            Assert.Equal(("a", Red), elements[0]);
+            Assert.Equal(("b", Green), elements[1]);
+            Assert.Equal(("c", Yellow), elements[2]);
+
+
+            value = new FormattedString(
+                "aaa bb c",
+                new FormatSpan(0, 3, Red),
+                new FormatSpan(4, 2, Green),
+                new FormatSpan(7, 1, Yellow));
+
+            elements = value.EnumerateTextElements().ToArray();
+            Assert.Equal(8, elements.Length);
+            Assert.Equal(("a", Red), elements[0]);
+            Assert.Equal(("a", Red), elements[1]);
+            Assert.Equal(("a", Red), elements[2]);
+            Assert.Equal((" ", ConsoleFormat.None), elements[3]);
+            Assert.Equal(("b", Green), elements[4]);
+            Assert.Equal(("b", Green), elements[5]);
+            Assert.Equal((" ", ConsoleFormat.None), elements[6]);
+            Assert.Equal(("c", Yellow), elements[7]);
+        }
     }
 }

--- a/tests/PrettyPrompt.Tests/WordWrappingTests.cs
+++ b/tests/PrettyPrompt.Tests/WordWrappingTests.cs
@@ -1,6 +1,7 @@
-﻿using PrettyPrompt.Consoles;
-using PrettyPrompt.Documents;
+﻿using System.Linq;
 using System.Text;
+using PrettyPrompt.Consoles;
+using PrettyPrompt.Documents;
 using Xunit;
 
 namespace PrettyPrompt.Tests
@@ -69,7 +70,7 @@ namespace PrettyPrompt.Tests
         public void WrapWords_GivenLongText_WrapsWords()
         {
             var text = "Here is some text that should be wrapped word by word. supercalifragilisticexpialidocious";
-            var wrapped = WordWrapping.WrapWords(text, 20);
+            var wrapped = WordWrapping.WrapWords(text, 20).Select(l => l.Text);
 
             Assert.Equal(
                 new[]
@@ -89,7 +90,7 @@ namespace PrettyPrompt.Tests
         public void WrapWords_WithNewLines_SplitsAtNewLines()
         {
             var text = "Here is some\ntext that should be wrapped word by\nword. supercalifragilisticexpialidocious";
-            var wrapped = WordWrapping.WrapWords(text, 20);
+            var wrapped = WordWrapping.WrapWords(text, 20).Select(l => l.Text);
 
             Assert.Equal(
                 new[]
@@ -109,7 +110,7 @@ namespace PrettyPrompt.Tests
         public void WrapWords_DoubleWidthCharacters_UsesUnicodeWidth()
         {
             var text = "每个人都有他的作战策略，直到脸上中了一拳。";
-            var wrapped = WordWrapping.WrapWords(text, 20);
+            var wrapped = WordWrapping.WrapWords(text, 20).Select(l => l.Text);
 
             Assert.Equal(
                 new[]


### PR DESCRIPTION
Hi!

This change enables you to format completion items and its description. Example:
![image](https://user-images.githubusercontent.com/11704036/143687666-18fdf965-3bff-470c-a8a5-7afed194e70a.png)

Primarily this change is prerequisite of improvements I'd like to make to to csharprepl completions.

Workhorse of this feature is new type ```FormattedString```, which is representation of ```string``` and optional collection of non-overlapping ```FormatSpan```s. It also has implemented lot of string-like methods like ```Replace```, ```Split```, ```Trim```, concatenation and so on. All this methods preserve formattings of inputs.

Then the interface of ```CompletionItem``` has been changed so it returns ```FormattedString``` instead of string for ```DisplayText``` and ```ExtendedDescription```. Implicit conversion from ```string``` to ```FormattedString``` exists.
Following changes were quite straightforward because ```FormattedString``` can be used very much like ```string```.
```FormattedString``` is unit tested because some of its method is more complex and there are lot of things that has to be handled.

I also changed the ```PrettyPrompt.Examples.FruitPrompt``` example in a way shown in screenshot above.

Hope you'll like it.