### PR TITLE
Word boundaries detection fix + respecting white spaces.

### DIFF
--- a/tests/PrettyPrompt.Tests/DocumentTests.cs
+++ b/tests/PrettyPrompt.Tests/DocumentTests.cs
@@ -1,0 +1,172 @@
+﻿#region License Header
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using PrettyPrompt.Documents;
+using Xunit;
+
+namespace PrettyPrompt.Tests
+{
+    public class DocumentTests
+    {
+        [Fact]
+        public void WordBoundariesTests_WithoutWhitspaces()
+        {
+            //empty
+            var document = new Document("", caret: 0);
+            for (int i = 0; i < 5; i++)
+            {
+                document.Caret = i;
+                Assert.Equal(0, document.CalculateWordBoundaryIndexNearCaret(1));
+                Assert.Equal(0, document.CalculateWordBoundaryIndexNearCaret(-1));
+            }
+
+
+            //single char
+            var testChars = new[] { 'a', '(' };
+            foreach (var c in testChars)
+            {
+                document = new Document($"{c}", caret: 0);
+                for (int i = 0; i < 4; i++)
+                {
+                    document.Caret = i;
+                    Assert.Equal(1, document.CalculateWordBoundaryIndexNearCaret(1));
+                    Assert.Equal(0, document.CalculateWordBoundaryIndexNearCaret(-1));
+                }
+            }
+
+
+            //two chars
+            IEnumerable<string> GetTestPairs(bool distinctChars)
+            {
+                var testPairs =
+                    from c1 in testChars
+                    from c2 in testChars
+                    select (c1, c2);
+                return testPairs.Where(p => distinctChars ? p.c1 != p.c2 : p.c1 == p.c2).Select(p => $"{p.c1}{p.c2}");
+            }
+            foreach (var text in GetTestPairs(distinctChars: true))
+            {
+                document = new Document(text, caret: 0);
+
+                document.Caret = 0;
+                Assert.Equal(1, document.CalculateWordBoundaryIndexNearCaret(1));
+                Assert.Equal(0, document.CalculateWordBoundaryIndexNearCaret(-1));
+
+                document.Caret = 1;
+                Assert.Equal(2, document.CalculateWordBoundaryIndexNearCaret(1));
+                Assert.Equal(0, document.CalculateWordBoundaryIndexNearCaret(-1));
+
+                document.Caret = 2;
+                Assert.Equal(2, document.CalculateWordBoundaryIndexNearCaret(1));
+                Assert.Equal(1, document.CalculateWordBoundaryIndexNearCaret(-1));
+            }
+            foreach (var text in GetTestPairs(distinctChars: false))
+            {
+                document = new Document(text, caret: 0);
+                for (int i = 0; i < 5; i++)
+                {
+                    document.Caret = i;
+                    Assert.Equal(2, document.CalculateWordBoundaryIndexNearCaret(1));
+                    Assert.Equal(0, document.CalculateWordBoundaryIndexNearCaret(-1));
+                }
+            }
+
+
+            //positions:             012345678
+            document = new Document(")))aaa(((", caret: 0);
+
+            //move right
+            for (int i = 0; i <= 2; i++)
+            {
+                document.Caret = i;
+                Assert.Equal(3, document.CalculateWordBoundaryIndexNearCaret(1));
+            }
+
+            for (int i = 3; i <= 5; i++)
+            {
+                document.Caret = i;
+                Assert.Equal(6, document.CalculateWordBoundaryIndexNearCaret(1));
+            }
+
+            for (int i = 6; i <= 10; i++)
+            {
+                document.Caret = i;
+                Assert.Equal(9, document.CalculateWordBoundaryIndexNearCaret(1));
+            }
+
+
+            //move left
+            for (int i = 10; i >= 7; i--)
+            {
+                document.Caret = i;
+                Assert.Equal(6, document.CalculateWordBoundaryIndexNearCaret(-1));
+            }
+
+            for (int i = 6; i >= 4; i--)
+            {
+                document.Caret = i;
+                Assert.Equal(3, document.CalculateWordBoundaryIndexNearCaret(-1));
+            }
+
+            for (int i = 3; i >= 0; i--)
+            {
+                document.Caret = i;
+                Assert.Equal(0, document.CalculateWordBoundaryIndexNearCaret(-1));
+            }
+        }
+
+        [Fact]
+        public void WordBoundariesTests_WithWhitspaces()
+        {
+            //Different editors have different behaviour regarding to whitespaces.
+            //Have tried Visual Studio vs Visual Studio Code vs Windows Terminal.
+            //VS behaves as Terminal. VsCode behaves diffrently. So VS/Terminal behaviour is implemented.
+
+            //whitespaces only
+            var document = new Document("   ", caret: 0);
+            for (int i = 0; i < 5; i++)
+            {
+                document.Caret = i;
+                Assert.Equal(document.GetText().Length, document.CalculateWordBoundaryIndexNearCaret(1));
+                Assert.Equal(0, document.CalculateWordBoundaryIndexNearCaret(-1));
+            }
+
+            //word + whitespaces (behaves like single word when going right;  behaves like two word when going left)
+            document = new Document("abc   ", caret: 0);
+            for (int i = 0; i < 10; i++)
+            {
+                document.Caret = i;
+                Assert.Equal(document.GetText().Length, document.CalculateWordBoundaryIndexNearCaret(1));
+                Assert.Equal(0, document.CalculateWordBoundaryIndexNearCaret(-1));
+            }
+
+            //whitespaces + word (behaves like two words)
+            document = new Document("   abc", caret: 0);
+            for (int i = 0; i <= 2; i++)
+            {
+                document.Caret = i;
+                Assert.Equal(3, document.CalculateWordBoundaryIndexNearCaret(1));
+            }
+            for (int i = 3; i < 10; i++)
+            {
+                document.Caret = i;
+                Assert.Equal(document.GetText().Length, document.CalculateWordBoundaryIndexNearCaret(1));
+            }
+            for (int i = 0; i <= 3; i++)
+            {
+                document.Caret = i;
+                Assert.Equal(0, document.CalculateWordBoundaryIndexNearCaret(-1));
+            }
+            for (int i = 4; i < 10; i++)
+            {
+                document.Caret = i;
+                Assert.Equal(3, document.CalculateWordBoundaryIndexNearCaret(-1));
+            }
+        }
+    }
+}

--- a/tests/PrettyPrompt.Tests/PromptTests.cs
+++ b/tests/PrettyPrompt.Tests/PromptTests.cs
@@ -159,8 +159,8 @@ namespace PrettyPrompt.Tests
             console.StubInput(
                 $"aaaa bbbb 5555{Shift}{Enter}",
                 $"dddd x5x5 foo.bar{Shift}{Enter}",
-                $"{UpArrow}{Control}{RightArrow}{Control}{RightArrow}{Control}{RightArrow}lum",
-                $"{Control}{LeftArrow}{Control}{LeftArrow}{Backspace}{Tab}",
+                $"{UpArrow}{Control}{RightArrow}{Control}{RightArrow}{Control}{RightArrow}{Control}{RightArrow}lum",
+                $"{Control}{LeftArrow}{Control}{LeftArrow}{Control}{LeftArrow}{Backspace}{Tab}",
                 $"{Enter}"
             );
 

--- a/tests/PrettyPrompt.Tests/SelectionTests.cs
+++ b/tests/PrettyPrompt.Tests/SelectionTests.cs
@@ -47,7 +47,7 @@ namespace PrettyPrompt.Tests
             var console = ConsoleStub.NewConsole();
             console.StubInput(
                 $"I am really happy!",
-                $"{Control}{LeftArrow}{Control}{LeftArrow}",
+                $"{Control}{LeftArrow}{Control}{LeftArrow}{Control}{LeftArrow}",
                 $"{Control | Shift}{RightArrow}so ",
                 $"{Shift}{LeftArrow}{Shift}{LeftArrow}{Shift}{LeftArrow}",
                 $"{Shift}{RightArrow}{Shift}{RightArrow}{Shift}{RightArrow}{Shift}{RightArrow}{Shift}{RightArrow}{Shift}{RightArrow}{Shift}{RightArrow}{Shift}{RightArrow}",
@@ -74,9 +74,9 @@ namespace PrettyPrompt.Tests
                 $"{UpArrow}{UpArrow}",
                 $"{Control}{LeftArrow}{Control}{LeftArrow}{LeftArrow}",
                 $"{Shift}{UpArrow}{Shift}{UpArrow}{Shift}{UpArrow}",
-                $"{Shift}{RightArrow}{Shift}{RightArrow}{Shift}{RightArrow}{Shift}{RightArrow}{Delete}",
+                $"{Shift}{RightArrow}{Shift}{RightArrow}{Shift}{RightArrow}{Shift}{RightArrow}{Delete}{Delete}",
                 $"{Shift}{RightArrow}{Shift}{RightArrow}{Shift}{Home}{Shift}{End}{Shift}{DownArrow}{Shift}{DownArrow}",
-                $"{Control | Shift}{End}{Control | Shift}{LeftArrow}{Shift}{LeftArrow}{Delete}{Enter}"
+                $"{Control | Shift}{End}{Control | Shift}{LeftArrow}{Control | Shift}{LeftArrow}{Shift}{LeftArrow}{Delete}{Enter}"
                 );
 
             var prompt = new Prompt(console: console);
@@ -109,7 +109,7 @@ namespace PrettyPrompt.Tests
             var console = ConsoleStub.NewConsole();
             console.StubInput(
                 $"It's a small world, after all",
-                $"{Control}{LeftArrow}{Control}{LeftArrow}{Control}{LeftArrow}{Control}{LeftArrow}",
+                $"{Control}{LeftArrow}{Control}{LeftArrow}{Control}{LeftArrow}{Control}{LeftArrow}{Control}{LeftArrow}",
                 $"{Control | Shift}{RightArrow}{Delete}",
                 $"{Control}{Z}",
                 $"{Control}{Y}{Control}{Y}{Enter}"
@@ -144,8 +144,8 @@ namespace PrettyPrompt.Tests
             var console = ConsoleStub.NewConsole();
             console.StubInput(
                 $"baby shark doo doo doo doo",
-                $"{Home}{Control | Shift}{RightArrow}{Control | Shift}{RightArrow}{Shift}{LeftArrow}{Shift}{LeftArrow}",
-                $"{Control}{X}{Delete}{End} {Control}{V}{Enter}"
+                $"{Home}{Control | Shift}{RightArrow}{Control | Shift}{RightArrow}{Shift}{LeftArrow}",
+                $"{Control}{X}{End} {Control}{V}{Backspace}{Enter}"
             );
 
             var prompt = new Prompt(console: console);


### PR DESCRIPTION
Hi,

this PR changes detection of word boundaries used while navigating through the input with arrow keys while Ctrl is pressed.

There was a bug in original implementation:
```C#
static bool IsWordStart(char c1, char c2) => !char.IsLetterOrDigit(c1) && char.IsLetterOrDigit(c2);
```
should be
```C#
static bool IsWordBoundary(char c1, char c2) =>char.IsLetterOrDigit(c1) != char.IsLetterOrDigit(c2);
```

And it didn't take whitespaces into account. I found out that different editors have different behavior regarding to whitespaces. I tried Visual Studio vs Visual Studio Code vs Windows Terminal. VS behaves as Terminal. VsCode behaves differently. So I implemented VS/Terminal behavior.

I also wrote tests and amend existing tests. I tried to 'execute' affected tests manually in VS and now it is consistent with PrettyPrompt implementation (=same sequence of keystrokes leads to same result - that wasn't true before).

There are more  differences, but here's one example. Having text ```(abc + def) / x``` and cursor at position 0, then repeated pressing of 'Ctrl+Shift+Right' leads to following:
Before:
![image](https://user-images.githubusercontent.com/11704036/143780837-478bbaea-691f-4e52-a905-6cc5d5d840f5.png)
After:
![image](https://user-images.githubusercontent.com/11704036/143780806-bd6610a4-e7b5-4239-ab69-806a9c9a6748.png)
