### PR TITLE
Reworked selection handling.

### DIFF
--- a/src/PrettyPrompt/Console/ConsoleCoordinate.cs
+++ b/src/PrettyPrompt/Console/ConsoleCoordinate.cs
@@ -33,10 +33,22 @@ namespace PrettyPrompt.Consoles
 
         public ConsoleCoordinate Offset(int rowOffset, int columnOffset) => new(Row + rowOffset, Column + columnOffset);
 
+        public static bool operator ==(ConsoleCoordinate left, ConsoleCoordinate right) => left.Equals(right);
+        public static bool operator !=(ConsoleCoordinate left, ConsoleCoordinate right) => !(left == right);
+
+        public static bool operator <(ConsoleCoordinate left, ConsoleCoordinate right)
+            => left.Row == right.Row ? left.Column < right.Column : left.Row < right.Row;
+
+        public static bool operator <=(ConsoleCoordinate left, ConsoleCoordinate right)
+            => left.Row == right.Row ? left.Column <= right.Column : left.Row <= right.Row;
+
+        public static bool operator >(ConsoleCoordinate left, ConsoleCoordinate right) => !(left <= right);
+        public static bool operator >=(ConsoleCoordinate left, ConsoleCoordinate right) => !(left < right);
+
         public override bool Equals(object obj) => obj is ConsoleCoordinate other && Equals(other);
         public bool Equals(ConsoleCoordinate other) => Row == other.Row && Column == other.Column;
         public bool Equals(int row, int column) => Row == row && Column == column;
         public override int GetHashCode() => HashCode.Combine(Row, Column);
-        public override string ToString() => $"Row {Row}, Column {Column}";
+        public override string ToString() => $"Row: {Row}, Column: {Column}";
     }
 }

--- a/src/PrettyPrompt/Console/ConsoleCoordinate.cs
+++ b/src/PrettyPrompt/Console/ConsoleCoordinate.cs
@@ -5,34 +5,38 @@
 #endregion
 
 using System;
+using System.Diagnostics;
 
 namespace PrettyPrompt.Consoles
 {
-    internal sealed class ConsoleCoordinate : IEquatable<ConsoleCoordinate>
+    internal readonly struct ConsoleCoordinate : IEquatable<ConsoleCoordinate>
     {
+        public readonly int Row;
+        public readonly int Column;
+
         public ConsoleCoordinate(int row, int column)
         {
+            Debug.Assert(row >= 0);
+            Debug.Assert(column >= 0);
+
             Row = row;
             Column = column;
         }
 
-        public int Row { get; set; }
-        public int Column { get; set; }
+        public ConsoleCoordinate MoveUp() => new(Math.Max(0, Row - 1), Column);
+        public ConsoleCoordinate MoveDown() => new(Row + 1, Column);
+        public ConsoleCoordinate MoveLeft() => new(Row, Math.Max(0, Column - 1));
+        public ConsoleCoordinate MoveRight() => new(Row, Column + 1);
 
-        public override bool Equals(object obj) =>
-            Equals(obj as ConsoleCoordinate);
+        public ConsoleCoordinate WithRow(int row) => new(row, Column);
+        public ConsoleCoordinate WithColumn(int column) => new(Row, column);
 
-        public bool Equals(ConsoleCoordinate other) =>
-            other != null
-            && Row == other.Row
-            && Column == other.Column;
+        public ConsoleCoordinate Offset(int rowOffset, int columnOffset) => new(Row + rowOffset, Column + columnOffset);
 
-        public override int GetHashCode() =>
-            HashCode.Combine(Row, Column);
-
-        public ConsoleCoordinate Clone(int rowOffset = 0, int columnOffset = 0) =>
-            new ConsoleCoordinate(Math.Max(0, Row + rowOffset), Math.Max(0, Column + columnOffset));
-
+        public override bool Equals(object obj) => obj is ConsoleCoordinate other && Equals(other);
+        public bool Equals(ConsoleCoordinate other) => Row == other.Row && Column == other.Column;
+        public bool Equals(int row, int column) => Row == row && Column == column;
+        public override int GetHashCode() => HashCode.Combine(Row, Column);
         public override string ToString() => $"Row {Row}, Column {Column}";
     }
 }

--- a/src/PrettyPrompt/Documents/Document.cs
+++ b/src/PrettyPrompt/Documents/Document.cs
@@ -32,7 +32,7 @@ namespace PrettyPrompt.Documents
         /// The two-dimensional coordinate of the text cursor in the document,
         /// after word wrapping / newlines have been processed.
         /// </summary>
-        public ConsoleCoordinate Cursor { get; private set; }
+        public ConsoleCoordinate Cursor { get; set; }
 
         /// <summary>
         /// After <see cref="WordWrap(int)"/> is called, this will contain the
@@ -40,8 +40,7 @@ namespace PrettyPrompt.Documents
         /// </summary>
         public IReadOnlyList<WrappedLine> WordWrappedLines { get; private set; }
 
-        public List<SelectionSpan> Selection { get; } = new();
-
+        public SelectionSpan? Selection { get; set; }
 
         public Document() : this(string.Empty, 0) { }
         public Document(string text, int caret)
@@ -62,19 +61,15 @@ namespace PrettyPrompt.Documents
 
         public void DeleteSelectedText()
         {
-            if (Selection.Count == 0) return;
-
-            undoRedoHistory.Track(this);
-            int firstSelectionStart = 0;
-            for (int i = Selection.Count - 1; i >= 0; i--)
+            if (Selection.TryGet(out var selection))
             {
-                var (start, end) = Selection[i].GetCaretIndices(WordWrappedLines);
+                undoRedoHistory.Track(this);
+                var (start, end) = selection.GetCaretIndices(WordWrappedLines);
                 text.Remove(start, end - start);
-                firstSelectionStart = start;
-            }
 
-            Caret = firstSelectionStart;
-            undoRedoHistory.Track(this);
+                Caret = start;
+                undoRedoHistory.Track(this);
+            }
         }
 
         public void InsertAtCaret(string text)

--- a/src/PrettyPrompt/Documents/WordWrapping.cs
+++ b/src/PrettyPrompt/Documents/WordWrapping.cs
@@ -24,17 +24,19 @@ namespace PrettyPrompt.Documents
         /// </summary>
         public static WordWrappedText WrapEditableCharacters(StringBuilder input, int initialCaretPosition, int width)
         {
-            var cursor = new ConsoleCoordinate(0, 0);
             if (input.Length == 0)
             {
-                cursor.Column = initialCaretPosition;
-                return new WordWrappedText(new[] { new WrappedLine(0, string.Empty) }, cursor);
+                return new WordWrappedText(
+                    new[] { new WrappedLine(0, string.Empty) }, 
+                    new ConsoleCoordinate(0, initialCaretPosition));
             }
 
             var lines = new List<WrappedLine>();
             int currentLineLength = 0;
             var line = new StringBuilder(width);
             int textIndex = 0;
+            int cursorColumn = 0;
+            int cursorRow = 0;
             foreach (ReadOnlyMemory<char> chunk in input.GetChunks())
             {
                 for(var i = 0; i < chunk.Span.Length; i++)
@@ -48,15 +50,15 @@ namespace PrettyPrompt.Documents
 
                     if (isCursorPastCharacter && !char.IsControl(character))
                     {
-                        cursor.Column++;
+                        cursorColumn++;
                     }
                     if (character == '\n' || currentLineLength == width ||
                         NextCharacterIsFullWidthAndWillWrap(width, currentLineLength, chunk, i))
                     {
                         if (isCursorPastCharacter)
                         {
-                            cursor.Row++;
-                            cursor.Column = 0;
+                            cursorRow++;
+                            cursorColumn = 0;
                         }
                         lines.Add(new WrappedLine(textIndex - line.Length, line.ToString()));
                         line = new StringBuilder();
@@ -68,7 +70,7 @@ namespace PrettyPrompt.Documents
             if (currentLineLength > 0)
                 lines.Add(new WrappedLine(textIndex - line.Length, line.ToString()));
 
-            return new WordWrappedText(lines, cursor);
+            return new WordWrappedText(lines, new ConsoleCoordinate(cursorRow, cursorColumn));
         }
 
         private static bool NextCharacterIsFullWidthAndWillWrap(int width, int currentLineLength, ReadOnlyMemory<char> chunk, int i) =>

--- a/src/PrettyPrompt/Extensions.cs
+++ b/src/PrettyPrompt/Extensions.cs
@@ -4,11 +4,11 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #endregion
 
-using PrettyPrompt.Rendering;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using PrettyPrompt.Rendering;
 
 namespace PrettyPrompt
 {
@@ -22,7 +22,7 @@ namespace PrettyPrompt
         public static IEnumerable<string> EnumerateTextElements(this string text)
         {
             var enumerator = StringInfo.GetTextElementEnumerator(text);
-            while(enumerator.MoveNext())
+            while (enumerator.MoveNext())
             {
                 yield return enumerator.GetTextElement();
             }
@@ -43,7 +43,7 @@ namespace PrettyPrompt
             foreach (var c in str)
             {
                 var cWidth = UnicodeWidth.GetWidth(c);
-                if(width + cWidth > maxChunkSize)
+                if (width + cWidth > maxChunkSize)
                 {
                     yield return buffer.ToString();
                     buffer.Clear();
@@ -53,7 +53,7 @@ namespace PrettyPrompt
                 buffer.Append(c);
             }
 
-            if(buffer.Length > 0)
+            if (buffer.Length > 0)
             {
                 yield return buffer.ToString();
             }
@@ -90,6 +90,21 @@ namespace PrettyPrompt
                 hasLeft = leftEnumerator.MoveNext();
                 hasRight = rightEnumerator.MoveNext();
                 i++;
+            }
+        }
+
+        public static bool TryGet<T>(this T? nullableValue, out T value)
+            where T : struct
+        {
+            if (nullableValue.HasValue)
+            {
+                value = nullableValue.GetValueOrDefault();
+                return true;
+            }
+            else
+            {
+                value = default;
+                return false;
             }
         }
     }

--- a/src/PrettyPrompt/Highlighting/CellRenderer.cs
+++ b/src/PrettyPrompt/Highlighting/CellRenderer.cs
@@ -66,17 +66,17 @@ namespace PrettyPrompt.Highlighting
                     }
 
                     // if there's text selected, invert colors to represent the highlight of the selected text.
-                    if (selectionStart.Equals(lineIndex, cellIndex - lineFullWidthCharacterOffset))
+                    if (selectionStart.Equals(lineIndex, cellIndex - lineFullWidthCharacterOffset)) //start is inclusive
                     {
                         selectionHighlight = true;
+                    }
+                    if (selectionEnd.Equals(lineIndex, cellIndex - lineFullWidthCharacterOffset)) //end is exclusive
+                    {
+                        selectionHighlight = false;
                     }
                     if (selectionHighlight)
                     {
                         cell.Formatting = new ConsoleFormat { Inverted = true };
-                    }
-                    if (selectionEnd.Equals(lineIndex, cellIndex - lineFullWidthCharacterOffset))
-                    {
-                        selectionHighlight = false;
                     }
                 }
                 highlightedRows[lineIndex] = new Row(cells);

--- a/src/PrettyPrompt/Highlighting/CellRenderer.cs
+++ b/src/PrettyPrompt/Highlighting/CellRenderer.cs
@@ -4,11 +4,12 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #endregion
 
-using PrettyPrompt.Documents;
-using PrettyPrompt.TextSelection;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using PrettyPrompt.Consoles;
+using PrettyPrompt.Documents;
+using PrettyPrompt.TextSelection;
 
 namespace PrettyPrompt.Highlighting
 {
@@ -17,10 +18,16 @@ namespace PrettyPrompt.Highlighting
     /// </summary>
     static class CellRenderer
     {
-        public static Row[] ApplyColorToCharacters(IReadOnlyCollection<FormatSpan> highlights, IReadOnlyList<WrappedLine> lines, IList<SelectionSpan> selections)
+        public static Row[] ApplyColorToCharacters(IReadOnlyCollection<FormatSpan> highlights, IReadOnlyList<WrappedLine> lines, SelectionSpan? selection)
         {
-            var selectionStart = selections.Select(s => (s.Start.Row, s.Start.Column)).ToHashSet();
-            var selectionEnd = selections.Select(s => (s.End.Row, s.End.Column)).ToHashSet();
+            var selectionStart = new ConsoleCoordinate(int.MaxValue, int.MaxValue); //invalid
+            var selectionEnd = new ConsoleCoordinate(int.MaxValue, int.MaxValue); //invalid
+            if (selection.TryGet(out var selectionValue))
+            {
+                selectionStart = selectionValue.Start;
+                selectionEnd = selectionValue.End;
+            }
+
             bool selectionHighlight = false;
 
             var highlightsLookup = highlights
@@ -59,15 +66,15 @@ namespace PrettyPrompt.Highlighting
                     }
 
                     // if there's text selected, invert colors to represent the highlight of the selected text.
-                    if (selectionStart.Contains((lineIndex, cellIndex - lineFullWidthCharacterOffset)))
+                    if (selectionStart.Equals(lineIndex, cellIndex - lineFullWidthCharacterOffset))
                     {
                         selectionHighlight = true;
                     }
-                    if(selectionHighlight)
+                    if (selectionHighlight)
                     {
                         cell.Formatting = new ConsoleFormat { Inverted = true };
                     }
-                    if (selectionEnd.Contains((lineIndex, cellIndex - lineFullWidthCharacterOffset)))
+                    if (selectionEnd.Equals(lineIndex, cellIndex - lineFullWidthCharacterOffset))
                     {
                         selectionHighlight = false;
                     }
@@ -101,7 +108,7 @@ namespace PrettyPrompt.Highlighting
         public static Row[] ApplyColorToCharacters(IReadOnlyCollection<FormatSpan> highlights, string text, int textWidth)
         {
             var wrapped = WordWrapping.WrapEditableCharacters(new System.Text.StringBuilder(text), 0, textWidth);
-            return ApplyColorToCharacters(highlights, wrapped.WrappedLines, Array.Empty<SelectionSpan>());
+            return ApplyColorToCharacters(highlights, wrapped.WrappedLines, null);
         }
     }
 }

--- a/src/PrettyPrompt/Panes/CompletionPane.cs
+++ b/src/PrettyPrompt/Panes/CompletionPane.cs
@@ -130,7 +130,7 @@ namespace PrettyPrompt.Panes
         }
 
         private static bool EnoughRoomToDisplay(CodePane codePane) =>
-            codePane.CodeAreaHeight - (codePane.Document.Cursor?.Row).GetValueOrDefault(0) >= VerticalPaddingHeight + 1; // offset + top border + 1 completion item + bottom border
+            codePane.CodeAreaHeight - codePane.Document.Cursor.Row >= VerticalPaddingHeight + 1; // offset + top border + 1 completion item + bottom border
 
         async Task IKeyPressHandler.OnKeyUp(KeyPress key)
         {

--- a/src/PrettyPrompt/TextSelection/SelectionSpan.cs
+++ b/src/PrettyPrompt/TextSelection/SelectionSpan.cs
@@ -5,6 +5,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using PrettyPrompt.Consoles;
 using PrettyPrompt.Documents;
 
@@ -12,32 +13,114 @@ namespace PrettyPrompt.TextSelection
 {
     internal readonly struct SelectionSpan
     {
-        public readonly ConsoleCoordinate Anchor;
-        public readonly ConsoleCoordinate Cursor;
+        /// <summary>
+        /// Inclusive.
+        /// </summary>
+        public readonly ConsoleCoordinate Start;
 
-        public ConsoleCoordinate Start => IsCursorPastAnchor() ? Anchor : Cursor;
-        public ConsoleCoordinate End => IsCursorPastAnchor() ? Cursor : Anchor;
+        /// <summary>
+        /// Exclusive.
+        /// </summary>
+        public readonly ConsoleCoordinate End;
 
-        public SelectionSpan(ConsoleCoordinate anchor, ConsoleCoordinate cursor)
+        public readonly SelectionDirection Direction;
+
+        public SelectionSpan(ConsoleCoordinate start, ConsoleCoordinate end, SelectionDirection direction)
         {
-            Anchor = anchor;
-            Cursor = cursor;
+            Debug.Assert(start >= new ConsoleCoordinate(0, 0));
+            Debug.Assert(start < end);
+
+            Start = start;
+            End = end;
+            Direction = direction;
         }
 
-        private bool IsCursorPastAnchor() =>
-            Anchor.Row < Cursor.Row || ((Anchor.Row == Cursor.Row) && Anchor.Column < Cursor.Column);
-
-        public (int start, int end) GetCaretIndices(IReadOnlyList<WrappedLine> wrappedLines)
+        public (int Start, int End) GetCaretIndices(IReadOnlyList<WrappedLine> wrappedLines)
         {
-            var start = Start;
-            var end = End;
-            var selectionStart = wrappedLines[start.Row].StartIndex + start.Column;
-            var selectionEnd = wrappedLines[end.Row].StartIndex + end.Column + 1;
-            if (end.Column == wrappedLines[end.Row].Content.Length)
-            {
-                selectionEnd--;
-            }
+            Debug.Assert(Start.Column <= wrappedLines[Start.Row].Content.Length);
+            //End.Row==wrappedLines.Count when last line ends with '\n' (-> End.Row is empty and not present in wrappedLines)
+            Debug.Assert(End.Row <= wrappedLines.Count);
+            Debug.Assert(End.Column <= (End.Row < wrappedLines.Count ? wrappedLines[End.Row].Content.Length : 0));
+
+            var selectionStart = wrappedLines[Start.Row].StartIndex + Start.Column;
+            var selectionEnd =
+                End.Row < wrappedLines.Count ?
+                wrappedLines[End.Row].StartIndex + End.Column :
+                wrappedLines[End.Row - 1].StartIndex + wrappedLines[End.Row - 1].Content.Length;
+
+            Debug.Assert(selectionStart < selectionEnd);
             return (selectionStart, selectionEnd);
         }
+
+        public SelectionSpan WithStart(ConsoleCoordinate start) => new(start, End, Direction);
+        public SelectionSpan WithEnd(ConsoleCoordinate end) => new(Start, end, Direction);
+
+        public SelectionSpan? GetUpdatedSelection(SelectionSpan newSelection)
+        {
+            if (Direction == SelectionDirection.FromLeftToRight)
+            {
+                if (newSelection.Direction == SelectionDirection.FromLeftToRight)
+                {
+                    Debug.Assert(newSelection.End > End);
+                    return ChangeEnd(this, newSelection.End);
+                }
+                else
+                {
+                    Debug.Assert(newSelection.End == End);
+                    return ChangeEnd(this, newSelection.Start);
+                }
+
+                static SelectionSpan? ChangeEnd(SelectionSpan selection, ConsoleCoordinate end)
+                {
+                    if (end > selection.Start)
+                    {
+                        return selection.WithEnd(end);
+                    }
+                    else
+                    {
+                        return
+                            end == selection.Start ?
+                            null : //cancelation of selection
+                            new(end, selection.Start, SelectionDirection.FromRightToLeft); //change of selection direction
+                    }
+                }
+            }
+            else
+            {
+                if (newSelection.Direction == SelectionDirection.FromLeftToRight)
+                {
+                    Debug.Assert(newSelection.Start == Start);
+                    return ChangeStart(this, newSelection.End);
+                }
+                else
+                {
+                    Debug.Assert(newSelection.End == Start);
+                    return ChangeStart(this, newSelection.Start);
+                }
+
+                static SelectionSpan? ChangeStart(SelectionSpan selection, ConsoleCoordinate start)
+                {
+                    if (start < selection.End)
+                    {
+                        return selection.WithStart(start);
+                    }
+                    else
+                    {
+                        return
+                            start == selection.End ?
+                            null : //cancelation of selection
+                            new(selection.End, start, SelectionDirection.FromLeftToRight); //change of selection direction
+                    }
+                }
+            }
+        }
+
+        public override string ToString() => $"Start: ({Start}), End: ({End})";
+    }
+
+    public enum SelectionDirection
+    {
+        FromLeftToRight,
+        FromRightToLeft
     }
 }

--- a/src/PrettyPrompt/TextSelection/SelectionSpan.cs
+++ b/src/PrettyPrompt/TextSelection/SelectionSpan.cs
@@ -4,27 +4,25 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #endregion
 
+using System.Collections.Generic;
 using PrettyPrompt.Consoles;
 using PrettyPrompt.Documents;
-using System.Collections.Generic;
 
 namespace PrettyPrompt.TextSelection
 {
-    internal class SelectionSpan
+    internal readonly struct SelectionSpan
     {
+        public readonly ConsoleCoordinate Anchor;
+        public readonly ConsoleCoordinate Cursor;
+
+        public ConsoleCoordinate Start => IsCursorPastAnchor() ? Anchor : Cursor;
+        public ConsoleCoordinate End => IsCursorPastAnchor() ? Cursor : Anchor;
+
         public SelectionSpan(ConsoleCoordinate anchor, ConsoleCoordinate cursor)
         {
             Anchor = anchor;
             Cursor = cursor;
         }
-
-        public ConsoleCoordinate Anchor { get; set; }
-
-        public ConsoleCoordinate Cursor { get; set; }
-
-        public ConsoleCoordinate Start => IsCursorPastAnchor() ? Anchor : Cursor;
-
-        public ConsoleCoordinate End => IsCursorPastAnchor() ? Cursor : Anchor;
 
         private bool IsCursorPastAnchor() =>
             Anchor.Row < Cursor.Row || ((Anchor.Row == Cursor.Row) && Anchor.Column < Cursor.Column);
@@ -35,7 +33,7 @@ namespace PrettyPrompt.TextSelection
             var end = End;
             var selectionStart = wrappedLines[start.Row].StartIndex + start.Column;
             var selectionEnd = wrappedLines[end.Row].StartIndex + end.Column + 1;
-            if(end.Column == wrappedLines[end.Row].Content.Length)
+            if (end.Column == wrappedLines[end.Row].Content.Length)
             {
                 selectionEnd--;
             }

--- a/tests/PrettyPrompt.Tests/OutputTests.cs
+++ b/tests/PrettyPrompt.Tests/OutputTests.cs
@@ -1,9 +1,5 @@
-﻿using PrettyPrompt.Highlighting;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System;
+using PrettyPrompt.Highlighting;
 using Xunit;
 using static PrettyPrompt.Consoles.AnsiEscapeCodes;
 
@@ -11,6 +7,14 @@ namespace PrettyPrompt.Tests
 {
     public class OutputTests
     {
+        [Fact]
+        public void RenderAnsiOutput_PlainText()
+        {
+            var output = Prompt.RenderAnsiOutput("here is some output", Array.Empty<FormatSpan>(), 100);
+
+            Assert.Equal("here is some output" + MoveCursorLeft(19), output);
+        }
+
         [Fact]
         public void RenderAnsiOutput_GivenFormat_AppliesAnsiEscapeSequences()
         {


### PR DESCRIPTION
Hey, 

I reworked selection handling which brings various fixes of previous issues + added more tests.

It mainly fixes following:

1. Suppose we have text 'abcd' and cursor before 'a'. Then 'right select' text 'abc' with Shift+Right. Then press Shift+Left.
    - Before:
      -  cursor moves back but selection stays same
![image](https://user-images.githubusercontent.com/11704036/144505671-4f22a3ab-1421-4b9d-99c1-87c77d53f13f.png)
    - After:
      -  cursor moves back and selection shrinkens
![image](https://user-images.githubusercontent.com/11704036/144505914-5d1f2f89-9b33-4d2c-8174-bcae6d53b03c.png)
2. After creating left or right selection it wasn't possible to remove selection by reducing its size to zero. For example again having text 'abcd' and cursor before 'c'. Then 'left select' text 'ab' with Shift+Left. Then 2x press Shift+Right.
    - Before:
      -  selection didn't vanish
![image](https://user-images.githubusercontent.com/11704036/144506974-918d6e92-fa26-442e-a001-fbb9c5661e42.png)
    - After:
      -  selection correctly vanishes
![image](https://user-images.githubusercontent.com/11704036/144507159-d0b8889c-ad41-4784-afd8-ef3504738309.png)
