### PR TITLE
Theme settings

### DIFF
--- a/examples/PrettyPrompt.Examples.FruitPrompt/Program.cs
+++ b/examples/PrettyPrompt.Examples.FruitPrompt/Program.cs
@@ -32,7 +32,7 @@ namespace PrettyPrompt
 
             while (true)
             {
-                var response = await prompt.ReadLineAsync("> ").ConfigureAwait(false);
+                var response = await prompt.ReadLineAsync().ConfigureAwait(false);
                 if (response.IsSuccess)
                 {
                     if (response.Text == "exit") break;

--- a/src/PrettyPrompt/PromptCallbacks.cs
+++ b/src/PrettyPrompt/PromptCallbacks.cs
@@ -55,7 +55,7 @@ namespace PrettyPrompt
     /// <item>
     /// If a non-null <see cref="KeyPressCallbackResult"/> is returned, the prompt will be submitted.
     /// The <see cref="KeyPressCallbackResult"/> will be returned by the current
-    /// <see cref="Prompt.ReadLineAsync(string)"/> function.
+    /// <see cref="Prompt.ReadLineAsync()"/> function.
     /// </item>
     /// <item>
     /// If a null <see cref="KeyPressCallbackResult"/> is returned, then the user will remain on the

--- a/src/PrettyPrompt/PromptTheme.cs
+++ b/src/PrettyPrompt/PromptTheme.cs
@@ -1,0 +1,38 @@
+﻿#nullable enable
+using System;
+using PrettyPrompt.Highlighting;
+
+namespace PrettyPrompt
+{
+    public class PromptTheme
+    {
+        /// <summary>
+        /// <code>true</code> if the user opted out of color, via an environment variable as specified by https://no-color.org/.
+        /// PrettyPrompt will automatically disable colors in this case. You can read this property to control other colors in
+        /// your application.
+        /// </summary>
+        public static bool HasUserOptedOutFromColor { get; } = Environment.GetEnvironmentVariable("NO_COLOR") is not null;
+
+        /// <summary>
+        /// The prompt string to draw (e.g. "> ")
+        /// </summary>
+        public string Prompt { get; }
+
+        public ConsoleFormat CompletionBorder { get; }
+
+        public ConsoleFormat DocumentationBorder { get; }
+
+        public PromptTheme(
+            string prompt = "> ",
+            ConsoleFormat? completionBorder = null,
+            ConsoleFormat? documentationBorder = null)
+        {
+            Prompt = prompt;
+
+            CompletionBorder = GetFormat(completionBorder ?? new ConsoleFormat(Foreground: AnsiColor.Blue));
+            DocumentationBorder = GetFormat(documentationBorder ?? new ConsoleFormat(Foreground: AnsiColor.Cyan));
+
+            static ConsoleFormat GetFormat(ConsoleFormat format) => HasUserOptedOutFromColor ? ConsoleFormat.None : format;
+        }
+    }
+}

--- a/tests/PrettyPrompt.Tests/ChineseJapaneseKoreanTests.cs
+++ b/tests/PrettyPrompt.Tests/ChineseJapaneseKoreanTests.cs
@@ -18,7 +18,7 @@ namespace PrettyPrompt.Tests
             console.StubInput($"书桌上有一个苹果。{Enter}");
 
             var prompt = new Prompt(console: console);
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.Equal("书桌上有一个苹果。", result.Text);
         }
@@ -30,7 +30,7 @@ namespace PrettyPrompt.Tests
             console.StubInput($"世界{LeftArrow}{LeftArrow}你好，{Enter}");
 
             var prompt = new Prompt(console: console);
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.Equal("你好，世界", result.Text);
         }
@@ -43,7 +43,7 @@ namespace PrettyPrompt.Tests
 
             var prompt = new Prompt(console: console);
 
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
             Assert.Equal("书桌上有", result.Text);
 
             var output = console.GetAllOutput();
@@ -66,7 +66,7 @@ namespace PrettyPrompt.Tests
             {
                 CompletionCallback = new CompletionTestData(new[] { "书桌上有" }).CompletionHandlerAsync
             });
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.Equal("书桌上有", result.Text);
         }
@@ -80,7 +80,7 @@ namespace PrettyPrompt.Tests
             console.StubInput($"书桌上有{Enter}");
 
             var prompt = new Prompt(console: console);
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             var output = console.GetAllOutput();
 

--- a/tests/PrettyPrompt.Tests/CompletionTests.cs
+++ b/tests/PrettyPrompt.Tests/CompletionTests.cs
@@ -29,7 +29,7 @@ namespace PrettyPrompt.Tests
                 console: console
             );
 
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.True(result.IsSuccess);
             Assert.Equal("Aardvark", result.Text);
@@ -44,7 +44,7 @@ namespace PrettyPrompt.Tests
 
             var prompt = ConfigurePrompt(console);
 
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.True(result.IsSuccess);
             Assert.Equal("Aardvark Zebra Alpaca", result.Text);
@@ -58,7 +58,7 @@ namespace PrettyPrompt.Tests
 
             var prompt = ConfigurePrompt(console);
 
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.True(result.IsSuccess);
             Assert.Equal($"Aardvark{NewLine}Zebra", result.Text);
@@ -72,7 +72,7 @@ namespace PrettyPrompt.Tests
 
             Prompt prompt = ConfigurePrompt(console);
 
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.True(result.IsSuccess);
             Assert.Equal($"Aardvark{NewLine}Zebra", result.Text);
@@ -86,14 +86,14 @@ namespace PrettyPrompt.Tests
 
             // Escape should close menu
             console.StubInput($"A{Escape}{Enter}"); // it will auto-open when we press A (see previous test)
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.True(result.IsSuccess);
             Assert.Equal($"A", result.Text);
 
             // Home key (among others) should close menu
             console.StubInput($"A{Home}{Enter}");
-            var result2 = await prompt.ReadLineAsync("> ");
+            var result2 = await prompt.ReadLineAsync();
 
             Assert.True(result2.IsSuccess);
             Assert.Equal($"A", result2.Text);
@@ -110,7 +110,7 @@ namespace PrettyPrompt.Tests
             );
             Prompt prompt = ConfigurePrompt(console);
 
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.True(result.IsSuccess);
             Assert.Equal($"Zebra", result.Text);
@@ -122,7 +122,7 @@ namespace PrettyPrompt.Tests
                 $"{Enter}{Enter}"
             );
 
-            var result2 = await prompt.ReadLineAsync("> ");
+            var result2 = await prompt.ReadLineAsync();
             Assert.True(result2.IsSuccess);
             Assert.Equal($"Aardvark", result2.Text);
         }
@@ -135,7 +135,7 @@ namespace PrettyPrompt.Tests
 
             var prompt = ConfigurePrompt(console);
 
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.True(result.IsSuccess);
             Assert.Equal($"Aardvark Aardvark", result.Text);
@@ -149,7 +149,7 @@ namespace PrettyPrompt.Tests
 
             var prompt = ConfigurePrompt(console);
 
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.True(result.IsSuccess);
             Assert.Equal($"Aardvark", result.Text);
@@ -163,7 +163,7 @@ namespace PrettyPrompt.Tests
 
             var prompt = ConfigurePrompt(console);
 
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.True(result.IsSuccess);
             Assert.Equal($"Aardvark a", result.Text);
@@ -177,7 +177,7 @@ namespace PrettyPrompt.Tests
 
             var prompt = ConfigurePrompt(console);
 
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.True(result.IsSuccess);
             Assert.Equal($"Aardvark Q", result.Text);

--- a/tests/PrettyPrompt.Tests/FuzzingTests.cs
+++ b/tests/PrettyPrompt.Tests/FuzzingTests.cs
@@ -41,7 +41,7 @@ namespace PrettyPrompt.Tests
 
             try
             {
-                var result = await prompt.ReadLineAsync("> ");
+                var result = await prompt.ReadLineAsync();
                 Assert.NotNull(result);
             }
             catch (Exception ex)

--- a/tests/PrettyPrompt.Tests/HistoryTests.cs
+++ b/tests/PrettyPrompt.Tests/HistoryTests.cs
@@ -20,7 +20,7 @@ namespace PrettyPrompt.Tests
             var prompt = new Prompt(console: console);
 
             console.StubInput($"{UpArrow}{UpArrow}{DownArrow}{DownArrow}yo world{Enter}");
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             // no exceptions, even though we cycled through history when there was no history to cycle through
             Assert.Equal("yo world", result.Text);
@@ -33,16 +33,16 @@ namespace PrettyPrompt.Tests
             var prompt = new Prompt(console: console);
 
             console.StubInput($"Hello World{Enter}");
-            await prompt.ReadLineAsync("> ");
+            await prompt.ReadLineAsync();
 
             console.StubInput($"Howdy World{Enter}");
-            await prompt.ReadLineAsync("> ");
+            await prompt.ReadLineAsync();
 
             console.StubInput($"How ya' doin world{Enter}");
-            await prompt.ReadLineAsync("> ");
+            await prompt.ReadLineAsync();
 
             console.StubInput($"{UpArrow}{UpArrow}{UpArrow}{DownArrow}{Enter}");
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.Equal("Howdy World", result.Text);
         }
@@ -54,29 +54,29 @@ namespace PrettyPrompt.Tests
             var prompt = new Prompt(console: console);
 
             console.StubInput($"Hello World{Enter}");
-            await prompt.ReadLineAsync("> ");
+            await prompt.ReadLineAsync();
 
             console.StubInput($"{Enter}");
-            await prompt.ReadLineAsync("> ");
+            await prompt.ReadLineAsync();
 
             console.StubInput($"{Enter}");
-            await prompt.ReadLineAsync("> ");
+            await prompt.ReadLineAsync();
 
             console.StubInput($"{UpArrow}{Enter}");
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
             Assert.Equal("Hello World", result.Text);
 
             console.StubInput($"Hellow{Enter}");
-            await prompt.ReadLineAsync("> ");
+            await prompt.ReadLineAsync();
 
             console.StubInput($"{Enter}");
-            await prompt.ReadLineAsync("> ");
+            await prompt.ReadLineAsync();
 
             console.StubInput($"{Enter}");
-            await prompt.ReadLineAsync("> ");
+            await prompt.ReadLineAsync();
 
             console.StubInput($"{UpArrow}{UpArrow}{Enter}");
-            result = await prompt.ReadLineAsync("> ");
+            result = await prompt.ReadLineAsync();
             Assert.Equal("Hello World", result.Text);
         }
 
@@ -87,24 +87,24 @@ namespace PrettyPrompt.Tests
             var prompt = new Prompt(console: console);
 
             console.StubInput($"howdy{Enter}");
-            await prompt.ReadLineAsync("> ");
+            await prompt.ReadLineAsync();
 
             console.StubInput($"Hello World{Enter}");
-            await prompt.ReadLineAsync("> ");
+            await prompt.ReadLineAsync();
 
             console.StubInput($"Hello World{Enter}");
-            await prompt.ReadLineAsync("> ");
+            await prompt.ReadLineAsync();
 
             console.StubInput($"Hello World{Enter}");
-            await prompt.ReadLineAsync("> ");
+            await prompt.ReadLineAsync();
 
             console.StubInput($"{UpArrow}{UpArrow}{Enter}");
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
             Assert.Equal("howdy", result.Text);
 
             // Current: howdy -> Hello World -> howdy.
             console.StubInput($"{UpArrow}{UpArrow}{UpArrow}{DownArrow}{Enter}");
-            result = await prompt.ReadLineAsync("> ");
+            result = await prompt.ReadLineAsync();
             Assert.Equal("Hello World", result.Text);
         }
 
@@ -115,10 +115,10 @@ namespace PrettyPrompt.Tests
             var prompt = new Prompt(console: console);
 
             console.StubInput($"Hello World{Enter}");
-            await prompt.ReadLineAsync("> ");
+            await prompt.ReadLineAsync();
 
             console.StubInput($"this prompt is my persistent storage{UpArrow}{DownArrow}{Enter}");
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.Equal("this prompt is my persistent storage", result.Text);
         }
@@ -130,16 +130,16 @@ namespace PrettyPrompt.Tests
             var prompt = new Prompt(console: console);
 
             console.StubInput($"one{Enter}");
-            await prompt.ReadLineAsync("> ");
+            await prompt.ReadLineAsync();
 
             console.StubInput($"two{Enter}");
-            await prompt.ReadLineAsync("> ");
+            await prompt.ReadLineAsync();
 
             console.StubInput(
                 $"{UpArrow}{Backspace}{Backspace}{Backspace}three{Backspace}{Backspace}{Backspace}{Backspace}",
                 $"{UpArrow}{Enter}"
             );
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.Equal("two", result.Text);
         }
@@ -150,14 +150,14 @@ namespace PrettyPrompt.Tests
             var console = ConsoleStub.NewConsole();
             var prompt = new Prompt(console: console);
             console.StubInput($"Entry One{Enter}");
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
             Assert.Equal("Entry One", result.Text);
 
             // second prompt, should not get history from first prompt
             console = ConsoleStub.NewConsole();
             prompt = new Prompt(console: console);
             console.StubInput($"{UpArrow}{Enter}");
-            result = await prompt.ReadLineAsync("> ");
+            result = await prompt.ReadLineAsync();
             Assert.Equal("", result.Text); // did not navigate to "Entry One" above
         }
 
@@ -168,13 +168,13 @@ namespace PrettyPrompt.Tests
             var prompt = new Prompt(console: console);
 
             console.StubInput($"one{Enter}");
-            await prompt.ReadLineAsync("> ");
+            await prompt.ReadLineAsync();
 
             console.StubInput($"two{Enter}");
-            await prompt.ReadLineAsync("> ");
+            await prompt.ReadLineAsync();
 
             console.StubInput($"o{UpArrow}{Enter}");
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.Equal("one", result.Text);
         }
@@ -190,14 +190,14 @@ namespace PrettyPrompt.Tests
             if(existingTextOnPrompt)
             {
                 console.StubInput($"apple{Enter}");
-                await prompt.ReadLineAsync("> ");
+                await prompt.ReadLineAsync();
 
                 console.StubInput($"banana{Enter}");
-                await prompt.ReadLineAsync("> ");
+                await prompt.ReadLineAsync();
             }
 
             console.StubInput($"zebr{UpArrow}{Enter}");
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.Equal("zebr", result.Text);
         }
@@ -210,13 +210,13 @@ namespace PrettyPrompt.Tests
             var console = ConsoleStub.NewConsole();
             var prompt = new Prompt(console: console, persistentHistoryFilepath: historyFile);
             console.StubInput($"Entry One{Enter}");
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
             Assert.Equal("Entry One", result.Text);
 
             console = ConsoleStub.NewConsole();
             prompt = new Prompt(console: console, persistentHistoryFilepath: historyFile);
             console.StubInput($"{UpArrow}{Enter}");
-            result = await prompt.ReadLineAsync("> ");
+            result = await prompt.ReadLineAsync();
             Assert.Equal("Entry One", result.Text); // did not navigate to "Entry One" above
         }
     }

--- a/tests/PrettyPrompt.Tests/PromptTests.cs
+++ b/tests/PrettyPrompt.Tests/PromptTests.cs
@@ -27,7 +27,7 @@ namespace PrettyPrompt.Tests
             console.StubInput($"Hello World{Enter}");
 
             var prompt = new Prompt(console: console);
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.True(result.IsSuccess);
             Assert.Equal("Hello World", result.Text);
@@ -40,7 +40,7 @@ namespace PrettyPrompt.Tests
             console.StubInput($"Hello World{Control}{Enter}");
 
             var prompt = new Prompt(console: console);
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.True(result.IsSuccess);
             Assert.True(result.IsHardEnter);
@@ -62,7 +62,7 @@ namespace PrettyPrompt.Tests
                 console: console
             );
 
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.True(result.IsSuccess);
             Assert.Equal("  ", result.Text);
@@ -75,7 +75,7 @@ namespace PrettyPrompt.Tests
             console.StubInput($"Hello World{Control}c");
 
             var prompt = new Prompt(console: console);
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.False(result.IsSuccess);
             Assert.Empty(result.Text);
@@ -89,7 +89,7 @@ namespace PrettyPrompt.Tests
             console.StubInput($"111222333{Control}{L}{Enter}");
 
             var prompt = new Prompt(console: console);
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.True(result.IsSuccess);
             Assert.Equal("111222333", result.Text);
@@ -113,7 +113,7 @@ namespace PrettyPrompt.Tests
             );
 
             var prompt = new Prompt(console: console);
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.Equal("prompt!", result.Text);
         }
@@ -128,7 +128,7 @@ namespace PrettyPrompt.Tests
             );
 
             var prompt = new Prompt(console: console);
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.Equal($"I say:{NewLine}{NewLine}Hello!{NewLine}World!", result.Text);
         }
@@ -147,7 +147,7 @@ namespace PrettyPrompt.Tests
             );
 
             var prompt = new Prompt(console: console);
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.Equal($"pretty well{NewLine}unit-tested?{NewLine}prompt!", result.Text);
         }
@@ -165,7 +165,7 @@ namespace PrettyPrompt.Tests
             );
 
             var prompt = new Prompt(console: console);
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.Equal($"aaaa bbbb 5555{NewLine}dddd x5x5    foo.lumbar{NewLine}", result.Text);
         }
@@ -182,7 +182,7 @@ namespace PrettyPrompt.Tests
             );
 
             var prompt = new Prompt(console: console);
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.Equal($"aaaa bbbb eeee ffff{NewLine}", result.Text);
         }
@@ -197,7 +197,7 @@ namespace PrettyPrompt.Tests
             console.StubInput($"abc{Enter}");
 
             var prompt = new Prompt(console: console);
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.Equal($"abc", result.Text);
         }
@@ -220,7 +220,7 @@ namespace PrettyPrompt.Tests
                 }
             }, console: console);
 
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.Equal("I am pasting content", result.Text);
             Assert.Equal(1, syntaxHighlightingInvocations);
@@ -237,7 +237,7 @@ namespace PrettyPrompt.Tests
 
             var prompt = new Prompt(console: console);
 
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.Equal($"indent{NewLine}    more indent{NewLine}{NewLine}indent", result.Text);
         }
@@ -258,7 +258,7 @@ namespace PrettyPrompt.Tests
                 }
             }, console: console);
 
-            _ = await prompt.ReadLineAsync("> ");
+            _ = await prompt.ReadLineAsync();
 
             Assert.Equal("I like apple", input);
             Assert.Equal(2, caret);
@@ -281,7 +281,7 @@ namespace PrettyPrompt.Tests
                 }
             }, console: console);
 
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.Equal(callbackOutput, result);
         }

--- a/tests/PrettyPrompt.Tests/SelectionTests.cs
+++ b/tests/PrettyPrompt.Tests/SelectionTests.cs
@@ -22,7 +22,7 @@ namespace PrettyPrompt.Tests
                 $"{Control}{LeftArrow}{Control}{LeftArrow}{Control | Shift}{RightArrow}enigmatic {Enter}");
             var prompt = new Prompt(console: console);
 
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.True(result.IsSuccess);
             Assert.Equal("The quick brown fox jumped over the enigmatic giraffe", result.Text);
@@ -35,7 +35,7 @@ namespace PrettyPrompt.Tests
             console.StubInput($"The quick brown fox jumped over the lazy dog{Control}{A}bonk{Enter}");
             var prompt = new Prompt(console: console);
 
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.True(result.IsSuccess);
             Assert.Equal("bonk", result.Text);
@@ -55,7 +55,7 @@ namespace PrettyPrompt.Tests
                 );
             var prompt = new Prompt(console: console);
 
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.True(result.IsSuccess);
             Assert.Equal("I am soup!", result.Text);
@@ -80,7 +80,7 @@ namespace PrettyPrompt.Tests
                 );
 
             var prompt = new Prompt(console: console);
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.True(result.IsSuccess);
             Assert.Equal("There once was rain!", result.Text);
@@ -97,7 +97,7 @@ namespace PrettyPrompt.Tests
                 $"{Control}{Z}{Enter}"
             );
             var prompt = new Prompt(console: console);
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.True(result.IsSuccess);
             Assert.Equal("It's a small world, after all", result.Text);
@@ -115,7 +115,7 @@ namespace PrettyPrompt.Tests
                 $"{Control}{Y}{Control}{Y}{Enter}"
             );
             var prompt = new Prompt(console: console);
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.True(result.IsSuccess);
             Assert.Equal("It's a world, after all", result.Text);
@@ -132,7 +132,7 @@ namespace PrettyPrompt.Tests
             );
 
             var prompt = new Prompt(console: console);
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.True(result.IsSuccess);
             Assert.Equal("baby shark doo doo doo doo", result.Text);
@@ -149,7 +149,7 @@ namespace PrettyPrompt.Tests
             );
 
             var prompt = new Prompt(console: console);
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.True(result.IsSuccess);
             Assert.Equal("doo doo doo doo baby shark", result.Text);
@@ -165,7 +165,7 @@ namespace PrettyPrompt.Tests
                 $"abcd",
                 $"{Shift}{Home}{Delete}{Enter}"
             );
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
             Assert.True(result.IsSuccess);
             Assert.Equal("", result.Text);
 
@@ -175,7 +175,7 @@ namespace PrettyPrompt.Tests
                 $"abcd",
                 $"{LeftArrow}{Shift}{LeftArrow}{Delete}{Enter}"
             );
-            result = await prompt.ReadLineAsync("> ");
+            result = await prompt.ReadLineAsync();
             Assert.True(result.IsSuccess);
             Assert.Equal("abd", result.Text);
          
@@ -185,7 +185,7 @@ namespace PrettyPrompt.Tests
                 $"abcd",
                 $"{LeftArrow}{Shift}{LeftArrow}{Shift}{LeftArrow}{Delete}{Enter}"
             );
-            result = await prompt.ReadLineAsync("> ");
+            result = await prompt.ReadLineAsync();
             Assert.True(result.IsSuccess);
             Assert.Equal("ad", result.Text);
 
@@ -195,7 +195,7 @@ namespace PrettyPrompt.Tests
                 $"abcd",
                 $"{LeftArrow}{Shift}{Home}{Delete}{Enter}"
             );
-            result = await prompt.ReadLineAsync("> ");
+            result = await prompt.ReadLineAsync();
             Assert.True(result.IsSuccess);
             Assert.Equal("d", result.Text);
         }
@@ -210,7 +210,7 @@ namespace PrettyPrompt.Tests
                 $"abcd",
                 $"{Home}{Shift}{End}{Delete}{Enter}"
             );
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
             Assert.True(result.IsSuccess);
             Assert.Equal("", result.Text);
 
@@ -220,7 +220,7 @@ namespace PrettyPrompt.Tests
                 $"abcd",
                 $"{Home}{RightArrow}{Shift}{RightArrow}{Delete}{Enter}"
             );
-            result = await prompt.ReadLineAsync("> ");
+            result = await prompt.ReadLineAsync();
             Assert.True(result.IsSuccess);
             Assert.Equal("acd", result.Text);
 
@@ -230,7 +230,7 @@ namespace PrettyPrompt.Tests
                 $"abcd",
                 $"{Home}{RightArrow}{Shift}{RightArrow}{Shift}{RightArrow}{Delete}{Enter}"
             );
-            result = await prompt.ReadLineAsync("> ");
+            result = await prompt.ReadLineAsync();
             Assert.True(result.IsSuccess);
             Assert.Equal("ad", result.Text);
 
@@ -240,7 +240,7 @@ namespace PrettyPrompt.Tests
                 $"abcd",
                 $"{Home}{RightArrow}{Shift}{End}{Delete}{Enter}"
             );
-            result = await prompt.ReadLineAsync("> ");
+            result = await prompt.ReadLineAsync();
             Assert.True(result.IsSuccess);
             Assert.Equal("a", result.Text);
         }
@@ -255,7 +255,7 @@ namespace PrettyPrompt.Tests
                 $"efgh",
                 $"{LeftArrow}{LeftArrow}{Shift}{UpArrow}{Delete}{Enter}"
             );
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
             Assert.True(result.IsSuccess);
             Assert.Equal("abgh", result.Text);
         }
@@ -270,7 +270,7 @@ namespace PrettyPrompt.Tests
                 $"efgh",
                 $"{Control}{Home}{RightArrow}{RightArrow}{Shift}{DownArrow}{Delete}{Enter}"
             );
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
             Assert.True(result.IsSuccess);
             Assert.Equal("abgh", result.Text);
         }

--- a/tests/PrettyPrompt.Tests/SyntaxHighlightingTests.cs
+++ b/tests/PrettyPrompt.Tests/SyntaxHighlightingTests.cs
@@ -29,7 +29,7 @@ namespace PrettyPrompt.Tests
                 console: console
             );
 
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.True(result.IsSuccess);
             Assert.Equal("red green nocolor blue", result.Text);
@@ -72,7 +72,7 @@ namespace PrettyPrompt.Tests
                 console: console
             );
 
-            var result = await prompt.ReadLineAsync("> ");
+            var result = await prompt.ReadLineAsync();
 
             Assert.True(result.IsSuccess);
             Assert.Equal("苹果 o 蓝莓 o avocado o", result.Text);


### PR DESCRIPTION
Hi,

this PR is based on PR https://github.com/waf/PrettyPrompt/pull/17.

It adds new class ```Theme``` which contains settings of prompt string and border formatting of completion and documentation border.

Prompt was passed in each ```IPrompt.ReadLineAsync``` and border formattings were hardcoded. Now ```Prompt``` can be directly created with optional ```Theme``` instance.

```Theme``` also handles the ```HasUserOptedOutFromColor``` and disables default or custom formatting.

I will extend ```Theme``` class in follow up PR.