### PR TITLE
New selected completion item rendering + configurability

### DIFF
--- a/src/PrettyPrompt/PromptTheme.cs
+++ b/src/PrettyPrompt/PromptTheme.cs
@@ -19,20 +19,30 @@ namespace PrettyPrompt
         public string Prompt { get; }
 
         public ConsoleFormat CompletionBorder { get; }
-
         public ConsoleFormat DocumentationBorder { get; }
+
+        public FormattedString SelectedCompletionItemMarker { get; }
+        public string UnselectedCompletionItemMarker { get; }
+        public AnsiColor? SelectedCompletionItemBackground { get; }
 
         public PromptTheme(
             string prompt = "> ",
             ConsoleFormat? completionBorder = null,
-            ConsoleFormat? documentationBorder = null)
+            ConsoleFormat? documentationBorder = null,
+            FormattedString? selectedCompletionItemMarkSymbol = null,
+            AnsiColor? selectedCompletionItemBackground = null)
         {
             Prompt = prompt;
 
             CompletionBorder = GetFormat(completionBorder ?? new ConsoleFormat(Foreground: AnsiColor.Blue));
             DocumentationBorder = GetFormat(documentationBorder ?? new ConsoleFormat(Foreground: AnsiColor.Cyan));
 
-            static ConsoleFormat GetFormat(ConsoleFormat format) => HasUserOptedOutFromColor ? ConsoleFormat.None : format;
+            SelectedCompletionItemMarker = selectedCompletionItemMarkSymbol ?? new FormattedString(">", new FormatSpan(0, 1, new ConsoleFormat(Foreground: DocumentationBorder.Foreground)));
+            UnselectedCompletionItemMarker = new string(' ', SelectedCompletionItemMarker.Length);
+            SelectedCompletionItemBackground = GetColor(selectedCompletionItemBackground ?? AnsiColor.RGB(40, 30, 30));
+
+            ConsoleFormat GetFormat(ConsoleFormat format) => HasUserOptedOutFromColor ? ConsoleFormat.None : format;
+            AnsiColor? GetColor(AnsiColor color) => HasUserOptedOutFromColor ? null : color;
         }
     }
 }

--- a/src/PrettyPrompt/Rendering/Cell.cs
+++ b/src/PrettyPrompt/Rendering/Cell.cs
@@ -56,6 +56,9 @@ namespace PrettyPrompt
             this.ElementWidth = elementWidth;
         }
 
+        public static List<Cell> FromText(char text, ConsoleFormat formatting)
+            => FromText(new FormattedString(text.ToString(), formatting));
+
         public static List<Cell> FromText(string text, ConsoleFormat formatting)
             => FromText(new FormattedString(text, formatting));
 


### PR DESCRIPTION
New selected completion item rendering + configurable selected item background + configurable formatted selection marker.

Before (at least for me it was almost invisible):
![AYWp46WKeT](https://user-images.githubusercontent.com/11704036/144907941-93b73eaa-05d0-40df-80e2-c24caf86ec57.gif)

After (default):
![6efrzdrJGW](https://user-images.githubusercontent.com/11704036/144913309-6e780b1b-0249-4658-ba89-e94350c57934.gif)

After (example, custom selection background + custom formatted selection marker):
![Q09vHJvmGs](https://user-images.githubusercontent.com/11704036/144914102-0ff31537-9687-4ef2-8164-97e726ff9566.gif)
Configuration of example above:
```C#
new PromptTheme(
    selectedCompletionItemMarkSymbol: new FormattedString("==>",
        new FormatSpan(0, 1, new ConsoleFormat(Foreground: AnsiColor.Green)),
        new FormatSpan(1, 1, new ConsoleFormat(Foreground: AnsiColor.Yellow)),
        new FormatSpan(2, 1, new ConsoleFormat(Foreground: AnsiColor.Red))
        ),
    selectedCompletionItemBackground: AnsiColor.RGB(96, 80, 0));
```
