### PR TITLE
AnsiColor foreground/background merge

### DIFF
--- a/examples/PrettyPrompt.Examples.FruitPrompt/Program.cs
+++ b/examples/PrettyPrompt.Examples.FruitPrompt/Program.cs
@@ -51,13 +51,13 @@ internal static class Program
             ( "avocado", "a pear-shaped fruit with a rough leathery skin, smooth oily edible flesh, and a large stone.", AnsiColor.Green ),
             ( "banana", "a long curved fruit which grows in clusters and has soft pulpy flesh and yellow skin when ripe.", AnsiColor.BrightYellow ),
             ( "cantaloupe", "a small round melon of a variety with orange flesh and ribbed skin.", AnsiColor.Green ),
-            ( "grapefruit", "a large round yellow citrus fruit with an acid juicy pulp.", AnsiColor.RGB(224, 112, 124) ),
+            ( "grapefruit", "a large round yellow citrus fruit with an acid juicy pulp.", AnsiColor.ForegroundRgb(224, 112, 124) ),
             ( "grape", "a berry, typically green (classified as white), purple, red, or black, growing in clusters on a grapevine, eaten as fruit, and used in making wine.", AnsiColor.Blue ),
             ( "mango", "a fleshy, oval, yellowish-red tropical fruit that is eaten ripe or used green for pickles or chutneys.", AnsiColor.Yellow ),
             ( "melon", "the large round fruit of a plant of the gourd family, with sweet pulpy flesh and many seeds.", AnsiColor.Green ),
-            ( "orange", "a round juicy citrus fruit with a tough bright reddish-yellow rind.", AnsiColor.RGB(255, 165, 0) ),
+            ( "orange", "a round juicy citrus fruit with a tough bright reddish-yellow rind.", AnsiColor.ForegroundRgb(255, 165, 0) ),
             ( "pear", "a yellowish- or brownish-green edible fruit that is typically narrow at the stalk and wider toward the base, with sweet, slightly gritty flesh.", AnsiColor.Green ),
-            ( "peach", "a round stone fruit with juicy yellow flesh and downy pinkish-yellow skin.", AnsiColor.RGB(255, 229, 180) ),
+            ( "peach", "a round stone fruit with juicy yellow flesh and downy pinkish-yellow skin.", AnsiColor.ForegroundRgb(255, 229, 180) ),
             ( "pineapple", "a large juicy tropical fruit consisting of aromatic edible yellow flesh surrounded by a tough segmented skin and topped with a tuft of stiff leaves.", AnsiColor.BrightYellow ),
             ( "strawberry", "a sweet soft red fruit with a seed-studded surface.", AnsiColor.BrightRed ),
         };
@@ -68,8 +68,8 @@ internal static class Program
             ("green", AnsiColor.Green),
             ("yellow", AnsiColor.Yellow),
             ("blue", AnsiColor.Blue),
-            ("purple", AnsiColor.RGB(72, 0, 255)),
-            ("orange", AnsiColor.RGB(255, 165, 0) ),
+            ("purple", AnsiColor.ForegroundRgb(72, 0, 255)),
+            ("orange", AnsiColor.ForegroundRgb(255, 165, 0) ),
         };
 
     // demo completion algorithm callback

--- a/examples/PrettyPrompt.Examples.FruitPrompt/Program.cs
+++ b/examples/PrettyPrompt.Examples.FruitPrompt/Program.cs
@@ -46,28 +46,28 @@ internal static class Program
     // demo data
     private static readonly (string Name, string Description, AnsiColor Highlight)[] Fruits = new[]
     {
-            ( "apple", "the round fruit of a tree of the rose family, which typically has thin red or green skin and crisp flesh. Many varieties have been developed as dessert or cooking fruit or for making cider.", AnsiColor.BrightRed ),
-            ( "apricot", "a juicy, soft fruit, resembling a small peach, of an orange-yellow color.", AnsiColor.Yellow ),
-            ( "avocado", "a pear-shaped fruit with a rough leathery skin, smooth oily edible flesh, and a large stone.", AnsiColor.Green ),
-            ( "banana", "a long curved fruit which grows in clusters and has soft pulpy flesh and yellow skin when ripe.", AnsiColor.BrightYellow ),
-            ( "cantaloupe", "a small round melon of a variety with orange flesh and ribbed skin.", AnsiColor.Green ),
+            ( "apple", "the round fruit of a tree of the rose family, which typically has thin red or green skin and crisp flesh. Many varieties have been developed as dessert or cooking fruit or for making cider.", AnsiColor.BrightRed.Foreground ),
+            ( "apricot", "a juicy, soft fruit, resembling a small peach, of an orange-yellow color.", AnsiColor.Yellow.Foreground ),
+            ( "avocado", "a pear-shaped fruit with a rough leathery skin, smooth oily edible flesh, and a large stone.", AnsiColor.Green.Foreground ),
+            ( "banana", "a long curved fruit which grows in clusters and has soft pulpy flesh and yellow skin when ripe.", AnsiColor.BrightYellow.Foreground ),
+            ( "cantaloupe", "a small round melon of a variety with orange flesh and ribbed skin.", AnsiColor.Green.Foreground ),
             ( "grapefruit", "a large round yellow citrus fruit with an acid juicy pulp.", AnsiColor.ForegroundRgb(224, 112, 124) ),
-            ( "grape", "a berry, typically green (classified as white), purple, red, or black, growing in clusters on a grapevine, eaten as fruit, and used in making wine.", AnsiColor.Blue ),
-            ( "mango", "a fleshy, oval, yellowish-red tropical fruit that is eaten ripe or used green for pickles or chutneys.", AnsiColor.Yellow ),
-            ( "melon", "the large round fruit of a plant of the gourd family, with sweet pulpy flesh and many seeds.", AnsiColor.Green ),
+            ( "grape", "a berry, typically green (classified as white), purple, red, or black, growing in clusters on a grapevine, eaten as fruit, and used in making wine.", AnsiColor.Blue.Foreground ),
+            ( "mango", "a fleshy, oval, yellowish-red tropical fruit that is eaten ripe or used green for pickles or chutneys.", AnsiColor.Yellow.Foreground ),
+            ( "melon", "the large round fruit of a plant of the gourd family, with sweet pulpy flesh and many seeds.", AnsiColor.Green.Foreground ),
             ( "orange", "a round juicy citrus fruit with a tough bright reddish-yellow rind.", AnsiColor.ForegroundRgb(255, 165, 0) ),
-            ( "pear", "a yellowish- or brownish-green edible fruit that is typically narrow at the stalk and wider toward the base, with sweet, slightly gritty flesh.", AnsiColor.Green ),
+            ( "pear", "a yellowish- or brownish-green edible fruit that is typically narrow at the stalk and wider toward the base, with sweet, slightly gritty flesh.", AnsiColor.Green.Foreground ),
             ( "peach", "a round stone fruit with juicy yellow flesh and downy pinkish-yellow skin.", AnsiColor.ForegroundRgb(255, 229, 180) ),
-            ( "pineapple", "a large juicy tropical fruit consisting of aromatic edible yellow flesh surrounded by a tough segmented skin and topped with a tuft of stiff leaves.", AnsiColor.BrightYellow ),
-            ( "strawberry", "a sweet soft red fruit with a seed-studded surface.", AnsiColor.BrightRed ),
+            ( "pineapple", "a large juicy tropical fruit consisting of aromatic edible yellow flesh surrounded by a tough segmented skin and topped with a tuft of stiff leaves.", AnsiColor.BrightYellow.Foreground ),
+            ( "strawberry", "a sweet soft red fruit with a seed-studded surface.", AnsiColor.BrightRed.Foreground ),
         };
 
     private static readonly (string Name, AnsiColor Color)[] ColorsToHighlight = new[]
     {
-            ("red", AnsiColor.Red),
-            ("green", AnsiColor.Green),
-            ("yellow", AnsiColor.Yellow),
-            ("blue", AnsiColor.Blue),
+            ("red", AnsiColor.Red.Foreground),
+            ("green", AnsiColor.Green.Foreground),
+            ("yellow", AnsiColor.Yellow.Foreground),
+            ("blue", AnsiColor.Blue.Foreground),
             ("purple", AnsiColor.ForegroundRgb(72, 0, 255)),
             ("orange", AnsiColor.ForegroundRgb(255, 165, 0) ),
         };

--- a/src/PrettyPrompt/Console/AnsiEscapeCodes.cs
+++ b/src/PrettyPrompt/Console/AnsiEscapeCodes.cs
@@ -31,8 +31,8 @@ public static class AnsiEscapeCodes
     public static string MoveCursorRight(int count) => count == 0 ? "" : $"{Escape}[{count}C";
     public static string MoveCursorLeft(int count) => count == 0 ? "" : $"{Escape}[{count}D";
 
-    public static string ForegroundColor(byte r, byte g, byte b) => ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.RGB(r, g, b)));
-    public static string BackgroundColor(byte r, byte g, byte b) => ToAnsiEscapeSequence(new ConsoleFormat(Background: AnsiColor.RGB(r, g, b)));
+    public static string ForegroundColor(byte r, byte g, byte b) => ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.ForegroundRgb(r, g, b)));
+    public static string BackgroundColor(byte r, byte g, byte b) => ToAnsiEscapeSequence(new ConsoleFormat(Background: AnsiColor.BackgroundRgb(r, g, b)));
 
     public static readonly string Black = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.Black));
     public static readonly string Red = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.Red));

--- a/src/PrettyPrompt/Console/AnsiEscapeCodes.cs
+++ b/src/PrettyPrompt/Console/AnsiEscapeCodes.cs
@@ -4,8 +4,8 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #endregion
 
-using PrettyPrompt.Highlighting;
 using System.Linq;
+using PrettyPrompt.Highlighting;
 
 namespace PrettyPrompt.Consoles;
 
@@ -34,22 +34,23 @@ public static class AnsiEscapeCodes
     public static string ForegroundColor(byte r, byte g, byte b) => ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.ForegroundRgb(r, g, b)));
     public static string BackgroundColor(byte r, byte g, byte b) => ToAnsiEscapeSequence(new ConsoleFormat(Background: AnsiColor.BackgroundRgb(r, g, b)));
 
-    public static readonly string Black = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.Black));
-    public static readonly string Red = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.Red));
-    public static readonly string Green = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.Green));
-    public static readonly string Yellow = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.Yellow));
-    public static readonly string Blue = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.Blue));
-    public static readonly string Magenta = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.Magenta));
-    public static readonly string Cyan = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.Cyan));
-    public static readonly string White = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.White));
-    public static readonly string BrightBlack = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.BrightBlack));
-    public static readonly string BrightRed = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.BrightRed));
-    public static readonly string BrightGreen = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.BrightGreen));
-    public static readonly string BrightYellow = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.BrightYellow));
-    public static readonly string BrightBlue = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.BrightBlue));
-    public static readonly string BrightMagenta = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.BrightMagenta));
-    public static readonly string BrightCyan = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.BrightCyan));
-    public static readonly string BrightWhite = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.BrightWhite));
+    public static readonly PredefinedAnsiEscapeCode Black = new(AnsiColor.Black);
+    public static readonly PredefinedAnsiEscapeCode Red = new(AnsiColor.Red);
+    public static readonly PredefinedAnsiEscapeCode Green = new(AnsiColor.Green);
+    public static readonly PredefinedAnsiEscapeCode Yellow = new(AnsiColor.Yellow);
+    public static readonly PredefinedAnsiEscapeCode Blue = new(AnsiColor.Blue);
+    public static readonly PredefinedAnsiEscapeCode Magenta = new(AnsiColor.Magenta);
+    public static readonly PredefinedAnsiEscapeCode Cyan = new(AnsiColor.Cyan);
+    public static readonly PredefinedAnsiEscapeCode White = new(AnsiColor.White);
+    public static readonly PredefinedAnsiEscapeCode BrightBlack = new(AnsiColor.BrightBlack);
+    public static readonly PredefinedAnsiEscapeCode BrightRed = new(AnsiColor.BrightRed);
+    public static readonly PredefinedAnsiEscapeCode BrightGreen = new(AnsiColor.BrightGreen);
+    public static readonly PredefinedAnsiEscapeCode BrightYellow = new(AnsiColor.BrightYellow);
+    public static readonly PredefinedAnsiEscapeCode BrightBlue = new(AnsiColor.BrightBlue);
+    public static readonly PredefinedAnsiEscapeCode BrightMagenta = new(AnsiColor.BrightMagenta);
+    public static readonly PredefinedAnsiEscapeCode BrightCyan = new(AnsiColor.BrightCyan);
+    public static readonly PredefinedAnsiEscapeCode BrightWhite = new(AnsiColor.BrightWhite);
+
     public static readonly string Reset = $"{Escape}[0m";
 
     public static string SetColors(AnsiColor fg, AnsiColor bg) =>
@@ -60,21 +61,35 @@ public static class AnsiEscapeCodes
         + "["
         + string.Join(
             separator: ";",
-            values: (formatting.Inverted
-                ? new[]
+            values:
+            (
+                formatting.Inverted ?
+                new[]
                 {
                         ResetForegroundColor,
                         ResetBackgroundColor,
                         Reverse
-                }
-                : new[]
+                } :
+                new[]
                 {
-                        formatting.Foreground?.Foreground ?? ResetForegroundColor,
-                        formatting.Background?.Background ?? ResetBackgroundColor,
+                        formatting.Foreground?.Code?? ResetForegroundColor,
+                        formatting.Background?.Code ?? ResetBackgroundColor,
                         formatting.Bold ? Bold : null,
                         formatting.Underline ? Underline : null,
                 }
             ).Where(format => format is not null)
           )
         + "m";
+
+    public readonly struct PredefinedAnsiEscapeCode
+    {
+        public readonly string Foreground;
+        public readonly string Background;
+
+        public PredefinedAnsiEscapeCode(AnsiColor.PredefinedAnsiColor color)
+        {
+            Foreground = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: color.Foreground));
+            Background = ToAnsiEscapeSequence(new ConsoleFormat(Background: color.Background));
+        }
+    }
 }

--- a/src/PrettyPrompt/Highlighting/AnsiColor.cs
+++ b/src/PrettyPrompt/Highlighting/AnsiColor.cs
@@ -17,69 +17,52 @@ namespace PrettyPrompt.Highlighting;
 public sealed class AnsiColor : IEquatable<AnsiColor>
 {
     private readonly string friendlyName;
-    public string Foreground { get; }
-    public string Background { get; }
+    public string Code { get; }
 
-    private AnsiColor(string foreground, string background, string friendlyName)
+    private AnsiColor(string code, string friendlyName)
     {
-        this.Foreground = foreground;
-        this.Background = background;
+        this.Code = code;
         this.friendlyName = friendlyName;
     }
 
-    public static readonly AnsiColor Black = new("30", "40", nameof(Black));
-    public static readonly AnsiColor Red = new("31", "41", nameof(Red));
-    public static readonly AnsiColor Green = new("32", "42", nameof(Green));
-    public static readonly AnsiColor Yellow = new("33", "43", nameof(Yellow));
-    public static readonly AnsiColor Blue = new("34", "44", nameof(Blue));
-    public static readonly AnsiColor Magenta = new("35", "45", nameof(Magenta));
-    public static readonly AnsiColor Cyan = new("36", "46", nameof(Cyan));
-    public static readonly AnsiColor White = new("37", "47", nameof(White));
-    public static readonly AnsiColor BrightBlack = new("90", "100", nameof(BrightBlack));
-    public static readonly AnsiColor BrightRed = new("91", "101", nameof(BrightRed));
-    public static readonly AnsiColor BrightGreen = new("92", "102", nameof(BrightGreen));
-    public static readonly AnsiColor BrightYellow = new("93", "103", nameof(BrightYellow));
-    public static readonly AnsiColor BrightBlue = new("94", "104", nameof(BrightBlue));
-    public static readonly AnsiColor BrightMagenta = new("95", "105", nameof(BrightMagenta));
-    public static readonly AnsiColor BrightCyan = new("96", "106", nameof(BrightCyan));
-    public static readonly AnsiColor BrightWhite = new("97", "107", nameof(BrightWhite));
+    public static readonly PredefinedAnsiColor Black = new("30", "40", nameof(Black));
+    public static readonly PredefinedAnsiColor Red = new("31", "41", nameof(Red));
+    public static readonly PredefinedAnsiColor Green = new("32", "42", nameof(Green));
+    public static readonly PredefinedAnsiColor Yellow = new("33", "43", nameof(Yellow));
+    public static readonly PredefinedAnsiColor Blue = new("34", "44", nameof(Blue));
+    public static readonly PredefinedAnsiColor Magenta = new("35", "45", nameof(Magenta));
+    public static readonly PredefinedAnsiColor Cyan = new("36", "46", nameof(Cyan));
+    public static readonly PredefinedAnsiColor White = new("37", "47", nameof(White));
+    public static readonly PredefinedAnsiColor BrightBlack = new("90", "100", nameof(BrightBlack));
+    public static readonly PredefinedAnsiColor BrightRed = new("91", "101", nameof(BrightRed));
+    public static readonly PredefinedAnsiColor BrightGreen = new("92", "102", nameof(BrightGreen));
+    public static readonly PredefinedAnsiColor BrightYellow = new("93", "103", nameof(BrightYellow));
+    public static readonly PredefinedAnsiColor BrightBlue = new("94", "104", nameof(BrightBlue));
+    public static readonly PredefinedAnsiColor BrightMagenta = new("95", "105", nameof(BrightMagenta));
+    public static readonly PredefinedAnsiColor BrightCyan = new("96", "106", nameof(BrightCyan));
+    public static readonly PredefinedAnsiColor BrightWhite = new("97", "107", nameof(BrightWhite));
 
-    public static AnsiColor ForegroundRgb(byte r, byte g, byte b) => new($"38;2;{r};{g};{b}", null, "RGB foreground");
-    public static AnsiColor BackgroundRgb(byte r, byte g, byte b) => new(null, $"48;2;{r};{g};{b}", "RGB background");
-    public static AnsiColor Rgb(
-        byte foregroundR, byte foregroundG, byte foregroundB,
-        byte backgroundR, byte backgroundG, byte backgroundB)
-        => new($"38;2;{foregroundR};{foregroundG};{foregroundB}", $"48;2;{backgroundR};{backgroundG};{backgroundB}", "RGB");
+    public static AnsiColor ForegroundRgb(byte r, byte g, byte b) => new($"38;2;{r};{g};{b}", "RGB foreground");
+    public static AnsiColor BackgroundRgb(byte r, byte g, byte b) => new($"48;2;{r};{g};{b}", "RGB background");
 
-    public override bool Equals(object obj)
+    public override bool Equals(object obj) => Equals(obj as AnsiColor);
+    public bool Equals(AnsiColor other) => other != null && Code == other.Code;
+    public override int GetHashCode() => Code.GetHashCode();
+
+    public static bool operator ==(AnsiColor left, AnsiColor right) => EqualityComparer<AnsiColor>.Default.Equals(left, right);
+    public static bool operator !=(AnsiColor left, AnsiColor right) => !(left == right);
+
+    public override string ToString() => friendlyName;
+
+    public readonly struct PredefinedAnsiColor
     {
-        return Equals(obj as AnsiColor);
-    }
+        public readonly AnsiColor Foreground;
+        public readonly AnsiColor Background;
 
-    public bool Equals(AnsiColor other)
-    {
-        return other != null &&
-               Foreground == other.Foreground &&
-               Background == other.Background;
-    }
-
-    public override int GetHashCode()
-    {
-        return HashCode.Combine(Foreground, Background);
-    }
-
-    public static bool operator ==(AnsiColor left, AnsiColor right)
-    {
-        return EqualityComparer<AnsiColor>.Default.Equals(left, right);
-    }
-
-    public static bool operator !=(AnsiColor left, AnsiColor right)
-    {
-        return !(left == right);
-    }
-
-    public override string ToString()
-    {
-        return friendlyName;
+        public PredefinedAnsiColor(string foregroundCode, string backgroundCode, string name)
+        {
+            Foreground = new AnsiColor(foregroundCode, $"{name} foreground");
+            Background = new AnsiColor(backgroundCode, $"{name} background");
+        }
     }
 }

--- a/src/PrettyPrompt/Highlighting/AnsiColor.cs
+++ b/src/PrettyPrompt/Highlighting/AnsiColor.cs
@@ -18,10 +18,13 @@ public sealed class AnsiColor : IEquatable<AnsiColor>
 {
     private readonly string friendlyName;
     public string Code { get; }
+    public bool IsForeground { get; }
+    public bool IsBackground => !IsForeground;
 
-    private AnsiColor(string code, string friendlyName)
+    private AnsiColor(string code, bool isForeground, string friendlyName)
     {
         this.Code = code;
+        this.IsForeground = isForeground;
         this.friendlyName = friendlyName;
     }
 
@@ -42,8 +45,8 @@ public sealed class AnsiColor : IEquatable<AnsiColor>
     public static readonly PredefinedAnsiColor BrightCyan = new("96", "106", nameof(BrightCyan));
     public static readonly PredefinedAnsiColor BrightWhite = new("97", "107", nameof(BrightWhite));
 
-    public static AnsiColor ForegroundRgb(byte r, byte g, byte b) => new($"38;2;{r};{g};{b}", "RGB foreground");
-    public static AnsiColor BackgroundRgb(byte r, byte g, byte b) => new($"48;2;{r};{g};{b}", "RGB background");
+    public static AnsiColor ForegroundRgb(byte r, byte g, byte b) => new($"38;2;{r};{g};{b}", isForeground: true, "RGB foreground");
+    public static AnsiColor BackgroundRgb(byte r, byte g, byte b) => new($"48;2;{r};{g};{b}", isForeground: false, "RGB background");
 
     public override bool Equals(object obj) => Equals(obj as AnsiColor);
     public bool Equals(AnsiColor other) => other != null && Code == other.Code;
@@ -61,8 +64,8 @@ public sealed class AnsiColor : IEquatable<AnsiColor>
 
         public PredefinedAnsiColor(string foregroundCode, string backgroundCode, string name)
         {
-            Foreground = new AnsiColor(foregroundCode, $"{name} foreground");
-            Background = new AnsiColor(backgroundCode, $"{name} background");
+            Foreground = new AnsiColor(foregroundCode, isForeground: true, $"{name} foreground");
+            Background = new AnsiColor(backgroundCode, isForeground: false, $"{name} background");
         }
     }
 }

--- a/src/PrettyPrompt/Highlighting/AnsiColor.cs
+++ b/src/PrettyPrompt/Highlighting/AnsiColor.cs
@@ -44,7 +44,12 @@ public sealed class AnsiColor : IEquatable<AnsiColor>
     public static readonly AnsiColor BrightCyan = new("96", "106", nameof(BrightCyan));
     public static readonly AnsiColor BrightWhite = new("97", "107", nameof(BrightWhite));
 
-    public static AnsiColor RGB(byte r, byte g, byte b) => new($"38;2;{r};{g};{b}", $"48;2;{r};{g};{b}", "RGB");
+    public static AnsiColor ForegroundRgb(byte r, byte g, byte b) => new($"38;2;{r};{g};{b}", null, "RGB foreground");
+    public static AnsiColor BackgroundRgb(byte r, byte g, byte b) => new(null, $"48;2;{r};{g};{b}", "RGB background");
+    public static AnsiColor Rgb(
+        byte foregroundR, byte foregroundG, byte foregroundB,
+        byte backgroundR, byte backgroundG, byte backgroundB)
+        => new($"38;2;{foregroundR};{foregroundG};{foregroundB}", $"48;2;{backgroundR};{backgroundG};{backgroundB}", "RGB");
 
     public override bool Equals(object obj)
     {

--- a/src/PrettyPrompt/Highlighting/ConsoleFormat.cs
+++ b/src/PrettyPrompt/Highlighting/ConsoleFormat.cs
@@ -4,14 +4,55 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #endregion
 
+using System;
+
 namespace PrettyPrompt.Highlighting;
 
-public readonly record struct ConsoleFormat(
-    AnsiColor Foreground = null,
-    AnsiColor Background = null,
-    bool Bold = false,
-    bool Underline = false,
-    bool Inverted = false)
+public readonly record struct ConsoleFormat
 {
     public static ConsoleFormat None => default;
+
+    private readonly AnsiColor foreground;
+    private readonly AnsiColor background;
+
+    public ConsoleFormat(
+        AnsiColor Foreground = null,
+        AnsiColor Background = null,
+        bool Bold = false,
+        bool Underline = false,
+        bool Inverted = false)
+    {
+        if (!(Foreground?.IsForeground ?? true)) throw new ArgumentException("not foreground color", nameof(Foreground));
+        if (!(Background?.IsBackground ?? true)) throw new ArgumentException("not background color", nameof(Background));
+
+        this.foreground = Foreground;
+        this.background = Background;
+        this.Bold = Bold;
+        this.Underline = Underline;
+        this.Inverted = Inverted;
+    }
+
+    public AnsiColor Foreground
+    {
+        get => foreground;
+        init
+        {
+            if (!(value?.IsForeground ?? true)) throw new ArgumentException("not foreground color", nameof(Foreground));
+            foreground = value;
+        }
+    }
+
+    public AnsiColor Background
+    {
+        get => background;
+        init
+        {
+            if (!(value?.IsBackground ?? true)) throw new ArgumentException("not background color", nameof(Background));
+            background = value;
+        }
+    }
+
+    public bool Bold { get; init; }
+    public bool Underline { get; init; }
+    public bool Inverted { get; init; }
 }

--- a/src/PrettyPrompt/PromptTheme.cs
+++ b/src/PrettyPrompt/PromptTheme.cs
@@ -34,8 +34,8 @@ public class PromptTheme
     {
         Prompt = prompt;
 
-        CompletionBorder = GetFormat(completionBorder ?? new ConsoleFormat(Foreground: AnsiColor.Blue));
-        DocumentationBorder = GetFormat(documentationBorder ?? new ConsoleFormat(Foreground: AnsiColor.Cyan));
+        CompletionBorder = GetFormat(completionBorder ?? new ConsoleFormat(Foreground: AnsiColor.Blue.Foreground));
+        DocumentationBorder = GetFormat(documentationBorder ?? new ConsoleFormat(Foreground: AnsiColor.Cyan.Foreground));
 
         SelectedCompletionItemMarker = selectedCompletionItemMarkSymbol ?? new FormattedString(">", new FormatSpan(0, 1, new ConsoleFormat(Foreground: DocumentationBorder.Foreground)));
         UnselectedCompletionItemMarker = new string(' ', SelectedCompletionItemMarker.Length);

--- a/src/PrettyPrompt/PromptTheme.cs
+++ b/src/PrettyPrompt/PromptTheme.cs
@@ -39,7 +39,7 @@ public class PromptTheme
 
         SelectedCompletionItemMarker = selectedCompletionItemMarkSymbol ?? new FormattedString(">", new FormatSpan(0, 1, new ConsoleFormat(Foreground: DocumentationBorder.Foreground)));
         UnselectedCompletionItemMarker = new string(' ', SelectedCompletionItemMarker.Length);
-        SelectedCompletionItemBackground = GetColor(selectedCompletionItemBackground ?? AnsiColor.RGB(40, 30, 30));
+        SelectedCompletionItemBackground = GetColor(selectedCompletionItemBackground ?? AnsiColor.BackgroundRgb(40, 30, 30));
 
         ConsoleFormat GetFormat(ConsoleFormat format) => HasUserOptedOutFromColor ? ConsoleFormat.None : format;
         AnsiColor? GetColor(AnsiColor color) => HasUserOptedOutFromColor ? null : color;

--- a/tests/PrettyPrompt.Tests/FormattedStringBuilderTests.cs
+++ b/tests/PrettyPrompt.Tests/FormattedStringBuilderTests.cs
@@ -13,8 +13,8 @@ public class FormattedStringBuilderTests
         sb.Append("")
           .Append(FormattedString.Empty)
           .Append(new FormattedString(""))
-          .Append(new FormattedString("", new ConsoleFormat(Foreground: AnsiColor.Red)))
-          .Append(new FormattedString("", new FormatSpan(0, 0, new ConsoleFormat(Foreground: AnsiColor.Red))));
+          .Append(new FormattedString("", new ConsoleFormat(Foreground: AnsiColor.Red.Foreground)))
+          .Append(new FormattedString("", new FormatSpan(0, 0, new ConsoleFormat(Background: AnsiColor.Red.Background))));
 
         Assert.Equal(0, sb.Length);
         Assert.Equal(FormattedString.Empty, sb.ToFormattedString());
@@ -32,16 +32,16 @@ public class FormattedStringBuilderTests
 
         sb.Append("1")
           .Append(FormattedString.Empty)
-          .Append("2", new FormatSpan(0, 1, new ConsoleFormat(Foreground: AnsiColor.Red)))
-          .Append("34", new FormatSpan(0, 1, new ConsoleFormat(Foreground: AnsiColor.Green)), new FormatSpan(1, 1, new ConsoleFormat(Foreground: AnsiColor.Yellow)));
+          .Append("2", new FormatSpan(0, 1, new ConsoleFormat(Foreground: AnsiColor.Red.Foreground)))
+          .Append("34", new FormatSpan(0, 1, new ConsoleFormat(Background: AnsiColor.Green.Background)), new FormatSpan(1, 1, new ConsoleFormat(Foreground: AnsiColor.Yellow.Foreground)));
 
         Assert.Equal(4, sb.Length);
         Assert.Equal(
             new FormattedString(
                 "1234", 
-                new FormatSpan(1, 1, new ConsoleFormat(Foreground: AnsiColor.Red)),
-                new FormatSpan(2, 1, new ConsoleFormat(Foreground: AnsiColor.Green)),
-                new FormatSpan(3, 1, new ConsoleFormat(Foreground: AnsiColor.Yellow))), 
+                new FormatSpan(1, 1, new ConsoleFormat(Foreground: AnsiColor.Red.Foreground)),
+                new FormatSpan(2, 1, new ConsoleFormat(Background: AnsiColor.Green.Background)),
+                new FormatSpan(3, 1, new ConsoleFormat(Foreground: AnsiColor.Yellow.Foreground))), 
             sb.ToFormattedString());
 
         sb.Clear();

--- a/tests/PrettyPrompt.Tests/FormattedStringTests.cs
+++ b/tests/PrettyPrompt.Tests/FormattedStringTests.cs
@@ -6,9 +6,9 @@ namespace PrettyPrompt.Tests;
 
 public class FormattedStringTests
 {
-    private static readonly ConsoleFormat Red = new(Foreground: AnsiColor.Red);
-    private static readonly ConsoleFormat Green = new(Foreground: AnsiColor.Green);
-    private static readonly ConsoleFormat Yellow = new(Foreground: AnsiColor.Yellow);
+    private static readonly ConsoleFormat Red = new(Foreground: AnsiColor.Red.Foreground);
+    private static readonly ConsoleFormat Green = new(Foreground: AnsiColor.Green.Foreground);
+    private static readonly ConsoleFormat Yellow = new(Foreground: AnsiColor.Yellow.Foreground);
 
     [Fact]
     public void Concatenation_PreservesFormatting()

--- a/tests/PrettyPrompt.Tests/OutputTests.cs
+++ b/tests/PrettyPrompt.Tests/OutputTests.cs
@@ -20,12 +20,12 @@ public class OutputTests
     {
         var output = Prompt.RenderAnsiOutput("here is some output", new[]
         {
-                new FormatSpan(0, 4, new ConsoleFormat { Foreground = AnsiColor.Red }),
-                new FormatSpan(8, 4, new ConsoleFormat { Foreground = AnsiColor.Green }),
+                new FormatSpan(0, 4, new ConsoleFormat { Foreground = AnsiColor.Red.Foreground }),
+                new FormatSpan(8, 4, new ConsoleFormat { Foreground = AnsiColor.Green.Foreground }),
             }, 100);
 
         Assert.Equal(
-            Red + "here" + Reset + " is " + Green + "some" + Reset + " output" + MoveCursorLeft(19),
+            Red.Foreground + "here" + Reset + " is " + Green.Foreground + "some" + Reset + " output" + MoveCursorLeft(19),
             output
         );
     }
@@ -35,15 +35,15 @@ public class OutputTests
     {
         var output = Prompt.RenderAnsiOutput("here is some output", new[]
         {
-                new FormatSpan(0, 4, new ConsoleFormat { Foreground = AnsiColor.Red }),
-                new FormatSpan(8, 4, new ConsoleFormat { Foreground = AnsiColor.Green }),
+                new FormatSpan(0, 4, new ConsoleFormat { Foreground = AnsiColor.Red.Foreground }),
+                new FormatSpan(8, 4, new ConsoleFormat { Foreground = AnsiColor.Green.Foreground }),
             }, 4);
 
         Assert.Equal(
             expected:
-                Red + "here\n" + MoveCursorLeft(3) +
+                Red.Foreground + "here\n" + MoveCursorLeft(3) +
                 Reset + " is \n" + MoveCursorLeft(3) +
-                Green + "some\n" + MoveCursorLeft(3) +
+                Green.Foreground + "some\n" + MoveCursorLeft(3) +
                 Reset + " out\n" + MoveCursorLeft(3) +
                 "put" + MoveCursorLeft(3),
             actual: output

--- a/tests/PrettyPrompt.Tests/SyntaxHighlighterTestData.cs
+++ b/tests/PrettyPrompt.Tests/SyntaxHighlighterTestData.cs
@@ -18,9 +18,9 @@ public class SyntaxHighlighterTestData
     {
         this.highlights = colors ?? new Dictionary<string, AnsiColor>()
             {
-                { "red", AnsiColor.BrightRed },
-                { "green", AnsiColor.BrightGreen },
-                { "blue", AnsiColor.BrightBlue },
+                { "red", AnsiColor.BrightRed.Foreground },
+                { "green", AnsiColor.BrightGreen.Foreground },
+                { "blue", AnsiColor.BrightBlue.Foreground },
             };
     }
 

--- a/tests/PrettyPrompt.Tests/SyntaxHighlightingTests.cs
+++ b/tests/PrettyPrompt.Tests/SyntaxHighlightingTests.cs
@@ -38,15 +38,15 @@ public class SyntaxHighlightingTests
         // although the words are typed character-by-character, we should still "go back" and redraw
         // it once we know the word should be drawn in a syntax-highlighted color.
         Assert.Contains(
-            MoveCursorLeft("red".Length - 1) + BrightRed + "red" + Reset, // when we press 'd' go back two chars and to rewrite the word "red"
+            MoveCursorLeft("red".Length - 1) + BrightRed.Foreground + "red" + Reset, // when we press 'd' go back two chars and to rewrite the word "red"
             output
         );
         Assert.Contains(
-            MoveCursorLeft("green".Length - 1) + BrightGreen + "green" + Reset,
+            MoveCursorLeft("green".Length - 1) + BrightGreen.Foreground + "green" + Reset,
             output
         );
         Assert.Contains(
-            MoveCursorLeft("blue".Length - 1) + BrightBlue + "blue" + Reset,
+            MoveCursorLeft("blue".Length - 1) + BrightBlue.Foreground + "blue" + Reset,
             output
         );
 
@@ -64,9 +64,9 @@ public class SyntaxHighlightingTests
             {
                 HighlightCallback = new SyntaxHighlighterTestData(new Dictionary<string, AnsiColor>
                 {
-                        { "苹果", AnsiColor.Red },
-                        { "蓝莓", AnsiColor.Blue },
-                        { "avocado", AnsiColor.Green }
+                        { "苹果", AnsiColor.Red.Foreground },
+                        { "蓝莓", AnsiColor.Blue.Foreground },
+                        { "avocado", AnsiColor.Green.Foreground }
                 }).HighlightHandlerAsync
             },
             console: console
@@ -81,19 +81,19 @@ public class SyntaxHighlightingTests
         // although the words are typed character-by-character, we should still "go back" and redraw
         // it once we know the word should be drawn in a syntax-highlighted color.
         Assert.Contains(
-            MoveCursorLeft(2) + Red + "苹果" + Reset,
+            MoveCursorLeft(2) + Red.Foreground + "苹果" + Reset,
             output
         );
 
         Assert.Contains(
-            MoveCursorLeft(2) + Blue + "蓝莓" + Reset,
+            MoveCursorLeft(2) + Blue.Foreground + "蓝莓" + Reset,
             output
         );
 
         // avocado is green, but wrapped because the console width is narrow.
         Assert.Contains(
             output,
-            str => str.Contains(Green + "avoc\n")
+            str => str.Contains(Green.Foreground + "avoc\n")
         );
 
         Assert.Contains(


### PR DESCRIPTION
```AnsiColor``` held foreground/background values. 
```C#
public sealed class AnsiColor : IEquatable<AnsiColor>
{
    private readonly string friendlyName;
    public string Foreground { get; }
    public string Background { get; }
    ...
```
In conjunction with ```ConsoleFormat``` (holding foreground/background ```AnsiColor```) that made strange situation when single ```ConsoleFormat``` had 4 colors:
```C#
ConsoleFormat.Foreground.Foreground
ConsoleFormat.Foreground.Background
ConsoleFormat.Background.Foreground
ConsoleFormat.Background.Background
```
which was pretty confusing. Because of that, I've changed ```AnsiColor``` so it holds only one color and it knows if it's foreground or background color.
```C#
public sealed class AnsiColor : IEquatable<AnsiColor>
{
    private readonly string friendlyName;
    public string Code { get; }
    public bool IsForeground { get; }
    public bool IsBackground => !IsForeground;
    ...
}
```
It also affected predefined colors. Before ```AnsiColor.Red``` contained red foreground + red background. Now you have to select which one you want:
```AnsiColor.Red.Foreground``` or ```AnsiColor.Red.Background``` (which returns ```AnsiColor```).

Assigning foreground color to the background of ```ConsoleFormat``` (and vice versa) throws an exception.