### PR TITLE
Number of new lines rendered after prompt is relative to window height and respects min/max number of completion items we want to render in completion pane.

### DIFF
--- a/src/PrettyPrompt/Extensions.cs
+++ b/src/PrettyPrompt/Extensions.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace PrettyPrompt;
 
@@ -76,5 +77,8 @@ internal static class Extensions
        => new(character, consoleKey, shift, alt, control);
 
     public static int Clamp(this int value, int min, int max)
-        => value < min ? min : (value > max ? max : value);
+    {
+        Debug.Assert(min <= max);
+        return value < min ? min : (value > max ? max : value);
+    }
 }

--- a/src/PrettyPrompt/Panes/CompletionPane.cs
+++ b/src/PrettyPrompt/Panes/CompletionPane.cs
@@ -4,13 +4,13 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #endregion
 
-using PrettyPrompt.Completion;
-using PrettyPrompt.Consoles;
-using PrettyPrompt.Documents;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using PrettyPrompt.Completion;
+using PrettyPrompt.Consoles;
+using PrettyPrompt.Documents;
 using static System.ConsoleKey;
 using static System.ConsoleModifiers;
 
@@ -18,8 +18,22 @@ namespace PrettyPrompt.Panes;
 
 internal class CompletionPane : IKeyPressHandler
 {
-    private const int MaxCompletionCount = 10;
-    private const int VerticalPaddingHeight = 3; // cursor + top border + bottom border.
+    /// <summary>
+    /// Top border + bottom borde
+    /// </summary>
+    public const int VerticalBordersHeight = 2;
+
+    public const int MaxCompletionItemsCount = 10;
+
+    /// <summary>
+    /// How few completion items we are willing to render.
+    /// </summary>
+    public const int MinCompletionItemsCount = 1;
+
+    /// <summary>
+    /// Cursor + top border + bottom border.
+    /// </summary>
+    private const int VerticalPaddingHeight = 1 + VerticalBordersHeight;
 
     private readonly CodePane codePane;
     private readonly CompletionCallbackAsync complete;
@@ -130,7 +144,7 @@ internal class CompletionPane : IKeyPressHandler
     }
 
     private static bool EnoughRoomToDisplay(CodePane codePane) =>
-        codePane.CodeAreaHeight - codePane.Document.Cursor.Row >= VerticalPaddingHeight + 1; // offset + top border + 1 completion item + bottom border
+        codePane.CodeAreaHeight - codePane.Document.Cursor.Row >= VerticalPaddingHeight + MinCompletionItemsCount; // offset + top border + MinCompletionItemsCount + bottom border
 
     async Task IKeyPressHandler.OnKeyUp(KeyPress key)
     {
@@ -191,7 +205,7 @@ internal class CompletionPane : IKeyPressHandler
 
     private void FilterCompletions(CodePane codePane)
     {
-        int height = Math.Min(codePane.CodeAreaHeight - VerticalPaddingHeight, MaxCompletionCount);
+        int height = Math.Min(codePane.CodeAreaHeight - VerticalPaddingHeight, MaxCompletionItemsCount);
 
         var filtered = new List<CompletionItem>();
         var previouslySelectedItem = this.FilteredView.SelectedItem;

--- a/src/PrettyPrompt/Rendering/Renderer.cs
+++ b/src/PrettyPrompt/Rendering/Renderer.cs
@@ -26,8 +26,6 @@ namespace PrettyPrompt;
 /// </summary>
 internal class Renderer
 {
-    private const int BottomPadding = 6;
-
     private readonly IConsole console;
     private readonly PromptTheme theme;
 
@@ -43,7 +41,10 @@ internal class Renderer
     public void RenderPrompt()
     {
         // write some newlines to ensure we have enough room to render the completion pane.
-        console.Write(new string('\n', BottomPadding) + MoveCursorUp(BottomPadding) + MoveCursorToColumn(1) + Reset + theme.Prompt);
+        var min = CompletionPane.VerticalBordersHeight + CompletionPane.MinCompletionItemsCount;
+        var max = CompletionPane.VerticalBordersHeight + CompletionPane.MaxCompletionItemsCount;
+        var newLinesCount = (2 * console.WindowHeight / 5).Clamp(min, max);
+        console.Write(new string('\n', newLinesCount) + MoveCursorUp(newLinesCount) + MoveCursorToColumn(1) + Reset + theme.Prompt);
     }
 
     public async Task RenderOutput(PromptResult result, CodePane codePane, CompletionPane completionPane, IReadOnlyCollection<FormatSpan> highlights, KeyPress key)


### PR DESCRIPTION
Before we always rendered 6 new lines. Now we use 40% of window height and cut it off by min/max space we need to render the completion pane.
Min space = borders + 1 item
Max space = borders + 10 items

Before:
![image](https://user-images.githubusercontent.com/11704036/147858084-63cb94e5-e58d-478e-8d1b-9b55dcad078a.png)
After:
![image](https://user-images.githubusercontent.com/11704036/147858194-abb40946-11e3-472a-94ab-0c565af40d58.png)

------------

Before:
![image](https://user-images.githubusercontent.com/11704036/147858129-88340568-d0c4-4d8c-b7f1-c5de1736d592.png)
After:
![image](https://user-images.githubusercontent.com/11704036/147858173-5e7a4496-8318-45cc-b396-56aff3e343b4.png)

------------