### PR TITLE
Adaptive completion item's documentation box width.

### DIFF
--- a/src/PrettyPrompt/Panes/CompletionPane.cs
+++ b/src/PrettyPrompt/Panes/CompletionPane.cs
@@ -19,7 +19,12 @@ namespace PrettyPrompt.Panes;
 internal class CompletionPane : IKeyPressHandler
 {
     /// <summary>
-    /// Top border + bottom borde
+    /// Left padding + right padding + right border.
+    /// </summary>
+    public const int HorizontalBordersWidth = 3;
+
+    /// <summary>
+    /// Top border + bottom border.
     /// </summary>
     public const int VerticalBordersHeight = 2;
 


### PR DESCRIPTION
We always used 55 columns as the maximum for the width of the documentation box. Now it's adaptive and takes the current width of the code pane and height of the completion items list into account.

We try wrappings with different available horizontal sizes (30%, 40%, ..., 90% of available code pane width). We don't want 'too long and too thin' boxes but also we don't want 'too narrow and too high' ones. So we use two heuristics to select the 'right' proportions of the documentation box:
1) Primarily we want to use space preallocated by the completion items box.
2) We prefer boxes with an aspect ratio > 4 (which assumes we are trying different proportions in ascending order).


Examples:

Before:
![image](https://user-images.githubusercontent.com/11704036/147886947-93fb255e-06d7-4bd1-a89c-2c377377f458.png)

After:
![image](https://user-images.githubusercontent.com/11704036/147886926-36c21d15-2dce-4a59-8914-67b05c222518.png)


----------------------------------
----------------------------------


Before:
![image](https://user-images.githubusercontent.com/11704036/147886969-0c333a11-e7c1-4dd3-9065-19da1f2715ea.png)

After:
![image](https://user-images.githubusercontent.com/11704036/147886929-9f34f984-4da4-4e0e-a15c-98d64c4ce237.png)
