### PR TITLE
AnsiColor foreground/background are private

### DIFF
--- a/examples/PrettyPrompt.Examples.FruitPrompt/Program.cs
+++ b/examples/PrettyPrompt.Examples.FruitPrompt/Program.cs
@@ -51,13 +51,13 @@ internal static class Program
             ( "avocado", "a pear-shaped fruit with a rough leathery skin, smooth oily edible flesh, and a large stone.", AnsiColor.Green ),
             ( "banana", "a long curved fruit which grows in clusters and has soft pulpy flesh and yellow skin when ripe.", AnsiColor.BrightYellow ),
             ( "cantaloupe", "a small round melon of a variety with orange flesh and ribbed skin.", AnsiColor.Green ),
-            ( "grapefruit", "a large round yellow citrus fruit with an acid juicy pulp.", AnsiColor.RGB(224, 112, 124) ),
+            ( "grapefruit", "a large round yellow citrus fruit with an acid juicy pulp.", AnsiColor.Rgb(224, 112, 124) ),
             ( "grape", "a berry, typically green (classified as white), purple, red, or black, growing in clusters on a grapevine, eaten as fruit, and used in making wine.", AnsiColor.Blue ),
             ( "mango", "a fleshy, oval, yellowish-red tropical fruit that is eaten ripe or used green for pickles or chutneys.", AnsiColor.Yellow ),
             ( "melon", "the large round fruit of a plant of the gourd family, with sweet pulpy flesh and many seeds.", AnsiColor.Green ),
-            ( "orange", "a round juicy citrus fruit with a tough bright reddish-yellow rind.", AnsiColor.RGB(255, 165, 0) ),
+            ( "orange", "a round juicy citrus fruit with a tough bright reddish-yellow rind.", AnsiColor.Rgb(255, 165, 0) ),
             ( "pear", "a yellowish- or brownish-green edible fruit that is typically narrow at the stalk and wider toward the base, with sweet, slightly gritty flesh.", AnsiColor.Green ),
-            ( "peach", "a round stone fruit with juicy yellow flesh and downy pinkish-yellow skin.", AnsiColor.RGB(255, 229, 180) ),
+            ( "peach", "a round stone fruit with juicy yellow flesh and downy pinkish-yellow skin.", AnsiColor.Rgb(255, 229, 180) ),
             ( "pineapple", "a large juicy tropical fruit consisting of aromatic edible yellow flesh surrounded by a tough segmented skin and topped with a tuft of stiff leaves.", AnsiColor.BrightYellow ),
             ( "strawberry", "a sweet soft red fruit with a seed-studded surface.", AnsiColor.BrightRed ),
         };
@@ -68,8 +68,8 @@ internal static class Program
             ("green", AnsiColor.Green),
             ("yellow", AnsiColor.Yellow),
             ("blue", AnsiColor.Blue),
-            ("purple", AnsiColor.RGB(72, 0, 255)),
-            ("orange", AnsiColor.RGB(255, 165, 0) ),
+            ("purple", AnsiColor.Rgb(72, 0, 255)),
+            ("orange", AnsiColor.Rgb(255, 165, 0) ),
         };
 
     // demo completion algorithm callback

--- a/src/PrettyPrompt/Console/AnsiEscapeCodes.cs
+++ b/src/PrettyPrompt/Console/AnsiEscapeCodes.cs
@@ -4,8 +4,8 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #endregion
 
-using PrettyPrompt.Highlighting;
 using System.Linq;
+using PrettyPrompt.Highlighting;
 
 namespace PrettyPrompt.Consoles;
 
@@ -31,46 +31,28 @@ public static class AnsiEscapeCodes
     public static string MoveCursorRight(int count) => count == 0 ? "" : $"{Escape}[{count}C";
     public static string MoveCursorLeft(int count) => count == 0 ? "" : $"{Escape}[{count}D";
 
-    public static string ForegroundColor(byte r, byte g, byte b) => ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.RGB(r, g, b)));
-    public static string BackgroundColor(byte r, byte g, byte b) => ToAnsiEscapeSequence(new ConsoleFormat(Background: AnsiColor.RGB(r, g, b)));
-
-    public static readonly string Black = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.Black));
-    public static readonly string Red = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.Red));
-    public static readonly string Green = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.Green));
-    public static readonly string Yellow = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.Yellow));
-    public static readonly string Blue = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.Blue));
-    public static readonly string Magenta = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.Magenta));
-    public static readonly string Cyan = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.Cyan));
-    public static readonly string White = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.White));
-    public static readonly string BrightBlack = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.BrightBlack));
-    public static readonly string BrightRed = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.BrightRed));
-    public static readonly string BrightGreen = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.BrightGreen));
-    public static readonly string BrightYellow = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.BrightYellow));
-    public static readonly string BrightBlue = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.BrightBlue));
-    public static readonly string BrightMagenta = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.BrightMagenta));
-    public static readonly string BrightCyan = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.BrightCyan));
-    public static readonly string BrightWhite = ToAnsiEscapeSequence(new ConsoleFormat(Foreground: AnsiColor.BrightWhite));
     public static readonly string Reset = $"{Escape}[0m";
 
-    public static string SetColors(AnsiColor fg, AnsiColor bg) =>
-        ToAnsiEscapeSequence(new ConsoleFormat(Foreground: fg, Background: bg));
+    internal static string ToAnsiEscapeSequence(string colorCode) => $"{Escape}[{colorCode}m";
 
     public static string ToAnsiEscapeSequence(ConsoleFormat formatting) =>
        Escape
         + "["
         + string.Join(
             separator: ";",
-            values: (formatting.Inverted
-                ? new[]
+            values:
+            (
+                formatting.Inverted ?
+                new[]
                 {
                         ResetForegroundColor,
                         ResetBackgroundColor,
                         Reverse
-                }
-                : new[]
+                } :
+                new[]
                 {
-                        formatting.Foreground?.Foreground ?? ResetForegroundColor,
-                        formatting.Background?.Background ?? ResetBackgroundColor,
+                        formatting.ForegroundCode ?? ResetForegroundColor,
+                        formatting.BackgroundCode ?? ResetBackgroundColor,
                         formatting.Bold ? Bold : null,
                         formatting.Underline ? Underline : null,
                 }

--- a/src/PrettyPrompt/Highlighting/AnsiColor.cs
+++ b/src/PrettyPrompt/Highlighting/AnsiColor.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using PrettyPrompt.Consoles;
 
 namespace PrettyPrompt.Highlighting;
 
@@ -16,16 +17,9 @@ namespace PrettyPrompt.Highlighting;
 /// <remarks>https://en.wikipedia.org/wiki/ANSI_escape_code#Colors</remarks>
 public sealed class AnsiColor : IEquatable<AnsiColor>
 {
+    private readonly string foregroundCode;
+    private readonly string backgroundCode;
     private readonly string friendlyName;
-    public string Foreground { get; }
-    public string Background { get; }
-
-    private AnsiColor(string foreground, string background, string friendlyName)
-    {
-        this.Foreground = foreground;
-        this.Background = background;
-        this.friendlyName = friendlyName;
-    }
 
     public static readonly AnsiColor Black = new("30", "40", nameof(Black));
     public static readonly AnsiColor Red = new("31", "41", nameof(Red));
@@ -44,37 +38,30 @@ public sealed class AnsiColor : IEquatable<AnsiColor>
     public static readonly AnsiColor BrightCyan = new("96", "106", nameof(BrightCyan));
     public static readonly AnsiColor BrightWhite = new("97", "107", nameof(BrightWhite));
 
-    public static AnsiColor RGB(byte r, byte g, byte b) => new($"38;2;{r};{g};{b}", $"48;2;{r};{g};{b}", "RGB");
+    public static AnsiColor Rgb(byte r, byte g, byte b) => new($"38;2;{r};{g};{b}", $"48;2;{r};{g};{b}", "RGB color");
 
-    public override bool Equals(object obj)
+    public AnsiColor(string foregroundCode, string backgroundCode, string friendlyName)
     {
-        return Equals(obj as AnsiColor);
+        this.foregroundCode = foregroundCode;
+        this.backgroundCode = backgroundCode;
+        this.friendlyName = friendlyName;
     }
 
-    public bool Equals(AnsiColor other)
-    {
-        return other != null &&
-               Foreground == other.Foreground &&
-               Background == other.Background;
-    }
+    public string GetAnsiEscapeSequence(Type type = Type.Foreground) => AnsiEscapeCodes.ToAnsiEscapeSequence(GetCode(type));
+    internal string GetCode(Type type = Type.Foreground) => type == Type.Foreground ? foregroundCode : backgroundCode;
 
-    public override int GetHashCode()
-    {
-        return HashCode.Combine(Foreground, Background);
-    }
+    public override bool Equals(object obj) => Equals(obj as AnsiColor);
+    public bool Equals(AnsiColor other) => other != null && foregroundCode == other.foregroundCode && backgroundCode == other.backgroundCode;
+    public override int GetHashCode() => foregroundCode.GetHashCode();
 
-    public static bool operator ==(AnsiColor left, AnsiColor right)
-    {
-        return EqualityComparer<AnsiColor>.Default.Equals(left, right);
-    }
+    public static bool operator ==(AnsiColor left, AnsiColor right) => EqualityComparer<AnsiColor>.Default.Equals(left, right);
+    public static bool operator !=(AnsiColor left, AnsiColor right) => !(left == right);
 
-    public static bool operator !=(AnsiColor left, AnsiColor right)
-    {
-        return !(left == right);
-    }
+    public override string ToString() => friendlyName;
 
-    public override string ToString()
+    public enum Type
     {
-        return friendlyName;
+        Foreground,
+        Background
     }
 }

--- a/src/PrettyPrompt/Highlighting/ConsoleFormat.cs
+++ b/src/PrettyPrompt/Highlighting/ConsoleFormat.cs
@@ -4,14 +4,19 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #endregion
 
+#nullable enable
+
 namespace PrettyPrompt.Highlighting;
 
 public readonly record struct ConsoleFormat(
-    AnsiColor Foreground = null,
-    AnsiColor Background = null,
+    AnsiColor? Foreground = null,
+    AnsiColor? Background = null,
     bool Bold = false,
     bool Underline = false,
     bool Inverted = false)
 {
     public static ConsoleFormat None => default;
+
+    public string? ForegroundCode => Foreground?.GetCode(AnsiColor.Type.Foreground);
+    public string? BackgroundCode => Background?.GetCode(AnsiColor.Type.Background);
 }

--- a/src/PrettyPrompt/PromptConfiguration.cs
+++ b/src/PrettyPrompt/PromptConfiguration.cs
@@ -54,11 +54,11 @@ public class PromptConfiguration
         Prompt = prompt;
 
         CompletionBoxBorderFormat = GetFormat(completionBoxBorderFormat ?? new ConsoleFormat(Foreground: AnsiColor.Blue));
-        CompletionItemDocumentationPaneBackground = GetColor(completionItemDocumentationPaneBackground ?? AnsiColor.RGB(30, 30, 30));
+        CompletionItemDocumentationPaneBackground = GetColor(completionItemDocumentationPaneBackground ?? AnsiColor.Rgb(30, 30, 30));
 
         SelectedCompletionItemMarker = selectedCompletionItemMarkSymbol ?? new FormattedString(">", new FormatSpan(0, 1, new ConsoleFormat(Foreground: AnsiColor.Cyan)));
         UnselectedCompletionItemMarker = new string(' ', SelectedCompletionItemMarker.Length);
-        SelectedCompletionItemBackground = GetColor(selectedCompletionItemBackground ?? AnsiColor.RGB(30, 30, 30));
+        SelectedCompletionItemBackground = GetColor(selectedCompletionItemBackground ?? AnsiColor.Rgb(30, 30, 30));
 
         ConsoleFormat GetFormat(ConsoleFormat format) => HasUserOptedOutFromColor ? ConsoleFormat.None : format;
         AnsiColor? GetColor(AnsiColor color) => HasUserOptedOutFromColor ? null : color;

--- a/tests/PrettyPrompt.Tests/OutputTests.cs
+++ b/tests/PrettyPrompt.Tests/OutputTests.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using PrettyPrompt.Highlighting;
+﻿using PrettyPrompt.Highlighting;
 using Xunit;
 using static PrettyPrompt.Consoles.AnsiEscapeCodes;
+using static PrettyPrompt.Highlighting.AnsiColor;
 
 namespace PrettyPrompt.Tests;
 
@@ -10,7 +10,7 @@ public class OutputTests
     [Fact]
     public void RenderAnsiOutput_PlainText()
     {
-        var output = Prompt.RenderAnsiOutput("here is some output", Array.Empty<FormatSpan>(), 100);
+        var output = Prompt.RenderAnsiOutput("here is some output", System.Array.Empty<FormatSpan>(), 100);
 
         Assert.Equal("here is some output" + MoveCursorLeft(19), output);
     }
@@ -18,14 +18,16 @@ public class OutputTests
     [Fact]
     public void RenderAnsiOutput_GivenFormat_AppliesAnsiEscapeSequences()
     {
+        var format1 = new ConsoleFormat(Foreground: Red);
+        var format2 = new ConsoleFormat(Foreground: Green);
         var output = Prompt.RenderAnsiOutput("here is some output", new[]
         {
-                new FormatSpan(0, 4, new ConsoleFormat { Foreground = AnsiColor.Red }),
-                new FormatSpan(8, 4, new ConsoleFormat { Foreground = AnsiColor.Green }),
-            }, 100);
+                new FormatSpan(0, 4, format1),
+                new FormatSpan(8, 4, format2),
+        }, 100);
 
         Assert.Equal(
-            Red + "here" + Reset + " is " + Green + "some" + Reset + " output" + MoveCursorLeft(19),
+            ToAnsiEscapeSequence(format1) + "here" + Reset + " is " + ToAnsiEscapeSequence(format2) + "some" + Reset + " output" + MoveCursorLeft(19),
             output
         );
     }
@@ -33,17 +35,19 @@ public class OutputTests
     [Fact]
     public void RenderAnsiOutput_GivenFormatAndWrapping_AppliesAnsiEscapeSequences()
     {
+        var format1 = new ConsoleFormat(Foreground: Red);
+        var format2 = new ConsoleFormat(Foreground: Green);
         var output = Prompt.RenderAnsiOutput("here is some output", new[]
         {
-                new FormatSpan(0, 4, new ConsoleFormat { Foreground = AnsiColor.Red }),
-                new FormatSpan(8, 4, new ConsoleFormat { Foreground = AnsiColor.Green }),
-            }, 4);
+                new FormatSpan(0, 4, format1),
+                new FormatSpan(8, 4, format2),
+        }, 4);
 
         Assert.Equal(
             expected:
-                Red + "here\n" + MoveCursorLeft(3) +
+                ToAnsiEscapeSequence(format1) + "here\n" + MoveCursorLeft(3) +
                 Reset + " is \n" + MoveCursorLeft(3) +
-                Green + "some\n" + MoveCursorLeft(3) +
+                ToAnsiEscapeSequence(format2) + "some\n" + MoveCursorLeft(3) +
                 Reset + " out\n" + MoveCursorLeft(3) +
                 "put" + MoveCursorLeft(3),
             actual: output

--- a/tests/PrettyPrompt.Tests/SyntaxHighlighterTestData.cs
+++ b/tests/PrettyPrompt.Tests/SyntaxHighlighterTestData.cs
@@ -4,23 +4,27 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #endregion
 
-using PrettyPrompt.Highlighting;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using PrettyPrompt.Highlighting;
 
 namespace PrettyPrompt.Tests;
 
 public class SyntaxHighlighterTestData
 {
+    public static readonly ConsoleFormat RedFormat = new(Foreground: AnsiColor.BrightRed);
+    public static readonly ConsoleFormat GreenFormat = new(Foreground: AnsiColor.BrightGreen);
+    public static readonly ConsoleFormat BlueFormat = new(Foreground: AnsiColor.BrightBlue);
+
     private readonly IReadOnlyDictionary<string, AnsiColor> highlights;
 
     public SyntaxHighlighterTestData(IReadOnlyDictionary<string, AnsiColor> colors = null)
     {
         this.highlights = colors ?? new Dictionary<string, AnsiColor>()
             {
-                { "red", AnsiColor.BrightRed },
-                { "green", AnsiColor.BrightGreen },
-                { "blue", AnsiColor.BrightBlue },
+                { "red", RedFormat.Foreground},
+                { "green", GreenFormat.Foreground},
+                { "blue", BlueFormat.Foreground },
             };
     }
 

--- a/tests/PrettyPrompt.Tests/SyntaxHighlightingTests.cs
+++ b/tests/PrettyPrompt.Tests/SyntaxHighlightingTests.cs
@@ -4,12 +4,13 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #endregion
 
-using PrettyPrompt.Highlighting;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using PrettyPrompt.Highlighting;
 using Xunit;
-using static PrettyPrompt.Consoles.AnsiEscapeCodes;
 using static System.ConsoleKey;
+using static PrettyPrompt.Consoles.AnsiEscapeCodes;
+using static PrettyPrompt.Highlighting.AnsiColor;
 
 namespace PrettyPrompt.Tests;
 
@@ -38,15 +39,15 @@ public class SyntaxHighlightingTests
         // although the words are typed character-by-character, we should still "go back" and redraw
         // it once we know the word should be drawn in a syntax-highlighted color.
         Assert.Contains(
-            MoveCursorLeft("red".Length - 1) + BrightRed + "red" + Reset, // when we press 'd' go back two chars and to rewrite the word "red"
+            MoveCursorLeft("red".Length - 1) + ToAnsiEscapeSequence(SyntaxHighlighterTestData.RedFormat) + "red" + Reset, // when we press 'd' go back two chars and to rewrite the word "red"
             output
         );
         Assert.Contains(
-            MoveCursorLeft("green".Length - 1) + BrightGreen + "green" + Reset,
+            MoveCursorLeft("green".Length - 1) + ToAnsiEscapeSequence(SyntaxHighlighterTestData.GreenFormat) + "green" + Reset,
             output
         );
         Assert.Contains(
-            MoveCursorLeft("blue".Length - 1) + BrightBlue + "blue" + Reset,
+            MoveCursorLeft("blue".Length - 1) + ToAnsiEscapeSequence(SyntaxHighlighterTestData.BlueFormat) + "blue" + Reset,
             output
         );
 
@@ -56,6 +57,10 @@ public class SyntaxHighlightingTests
     [Fact]
     public async Task ReadLine_CJKCharacters_SyntaxHighlight()
     {
+        var format1 = new ConsoleFormat(Foreground: Red);
+        var format2 = new ConsoleFormat(Foreground: Blue);
+        var format3 = new ConsoleFormat(Foreground: Green);
+
         var console = ConsoleStub.NewConsole(width: 20);
         console.StubInput($"苹果 o 蓝莓 o avocado o{Enter}");
 
@@ -64,9 +69,9 @@ public class SyntaxHighlightingTests
             {
                 HighlightCallback = new SyntaxHighlighterTestData(new Dictionary<string, AnsiColor>
                 {
-                        { "苹果", AnsiColor.Red },
-                        { "蓝莓", AnsiColor.Blue },
-                        { "avocado", AnsiColor.Green }
+                        { "苹果", format1.Foreground },
+                        { "蓝莓", format2.Foreground },
+                        { "avocado", format3.Foreground }
                 }).HighlightHandlerAsync
             },
             console: console
@@ -81,19 +86,19 @@ public class SyntaxHighlightingTests
         // although the words are typed character-by-character, we should still "go back" and redraw
         // it once we know the word should be drawn in a syntax-highlighted color.
         Assert.Contains(
-            MoveCursorLeft(2) + Red + "苹果" + Reset,
+            MoveCursorLeft(2) + ToAnsiEscapeSequence(format1) + "苹果" + Reset,
             output
         );
 
         Assert.Contains(
-            MoveCursorLeft(2) + Blue + "蓝莓" + Reset,
+            MoveCursorLeft(2) + ToAnsiEscapeSequence(format2) + "蓝莓" + Reset,
             output
         );
 
         // avocado is green, but wrapped because the console width is narrow.
         Assert.Contains(
             output,
-            str => str.Contains(Green + "avoc\n")
+            str => str.Contains(ToAnsiEscapeSequence(format3) + "avoc\n")
         );
 
         Assert.Contains(


### PR DESCRIPTION
```AnsiColor``` does not anymore publicly expose Foreground/Background properties. There is now only an internal GetCode method that accepts Foreground/Background enum and it's used only in ```ConsoleFormat```.

Also ```AnsiEscapeCodes``` does not anymore hold codes for basic colors (because they were only for foreground). There is method ```GetAnsiEscapeSequence``` directly on ```AnsiColor``` now.