### PR TITLE
Move CodePane dependent members (Cursor, WordWrappedLines, Selection) from Document to CodePane.

### DIFF
--- a/src/PrettyPrompt/History/HistoryLog.cs
+++ b/src/PrettyPrompt/History/HistoryLog.cs
@@ -153,7 +153,7 @@ sealed class HistoryLog : IKeyPressHandler
         if (codepane.Document.Equals(contents)) return;
 
         codepane.Document.Clear();
-        codepane.Document.InsertAtCaret(contents.GetText());
+        codepane.Document.InsertAtCaret(contents.GetText(), codepane.GetSelectionStartEnd());
         codepane.WordWrap();
     }
 

--- a/src/PrettyPrompt/Panes/CompletionPane.cs
+++ b/src/PrettyPrompt/Panes/CompletionPane.cs
@@ -151,7 +151,7 @@ internal class CompletionPane : IKeyPressHandler
     }
 
     private bool EnoughRoomToDisplay(CodePane codePane) =>
-        codePane.CodeAreaHeight - codePane.Document.Cursor.Row >= VerticalPaddingHeight + minCompletionItemsCount; // offset + top border + MinCompletionItemsCount + bottom border
+        codePane.CodeAreaHeight - codePane.Cursor.Row >= VerticalPaddingHeight + minCompletionItemsCount; // offset + top border + MinCompletionItemsCount + bottom border
 
     async Task IKeyPressHandler.OnKeyUp(KeyPress key)
     {
@@ -274,7 +274,7 @@ internal class CompletionPane : IKeyPressHandler
     private void InsertCompletion(Document input, CompletionItem completion, string suffix = "")
     {
         input.Remove(completion.StartIndex, input.Caret - completion.StartIndex);
-        input.InsertAtCaret(completion.ReplacementText + suffix);
+        input.InsertAtCaret(completion.ReplacementText + suffix, codePane.GetSelectionStartEnd());
         input.Caret = completion.StartIndex + completion.ReplacementText.Length + suffix.Length;
         Close();
     }

--- a/src/PrettyPrompt/Rendering/Renderer.cs
+++ b/src/PrettyPrompt/Rendering/Renderer.cs
@@ -53,7 +53,7 @@ internal class Renderer
     {
         if (result is not null)
         {
-            if (wasTextSelectedDuringPreviousRender && codePane.Document.Selection is null)
+            if (wasTextSelectedDuringPreviousRender && codePane.Selection is null)
             {
                 await Redraw();
             }
@@ -65,7 +65,7 @@ internal class Renderer
             }
 
             Write(
-                MoveCursorDown(codePane.Document.WordWrappedLines.Count - codePane.Document.Cursor.Row - 1)
+                MoveCursorDown(codePane.WordWrappedLines.Count - codePane.Cursor.Row - 1)
                 + MoveCursorToColumn(1)
                 + "\n"
                 + ClearToEndOfScreen,
@@ -86,7 +86,7 @@ internal class Renderer
             await Redraw();
         }
 
-        wasTextSelectedDuringPreviousRender = codePane.Document.Selection.HasValue;
+        wasTextSelectedDuringPreviousRender = codePane.Selection.HasValue;
 
         async Task Redraw()
         {
@@ -94,7 +94,7 @@ internal class Renderer
             ScreenArea codeWidget = BuildCodeScreenArea(codePane, highlights);
             ScreenArea[] completionWidgets = await BuildCompletionScreenAreas(
                 completionPane,
-                cursor: codePane.Document.Cursor,
+                cursor: codePane.Cursor,
                 codeAreaStartColumn: configuration.Prompt.Length,
                 codeAreaWidth: codePane.CodeAreaWidth
             ).ConfigureAwait(false);
@@ -109,7 +109,7 @@ internal class Renderer
             // draw screen areas to screen representation.
             // later screen areas can overlap earlier screen areas.
             var screen = new Screen(
-                codePane.CodeAreaWidth, codePane.CodeAreaHeight, codePane.Document.Cursor, screenAreas: new[] { codeWidget }.Concat(completionWidgets).ToArray()
+                codePane.CodeAreaWidth, codePane.CodeAreaHeight, codePane.Cursor, screenAreas: new[] { codeWidget }.Concat(completionWidgets).ToArray()
             );
 
             if (DidCodeAreaResize(previouslyRenderedScreen, screen))
@@ -140,7 +140,7 @@ internal class Renderer
 
     private static ScreenArea BuildCodeScreenArea(CodePane codePane, IReadOnlyCollection<FormatSpan> highlights)
     {
-        var highlightedLines = CellRenderer.ApplyColorToCharacters(highlights, codePane.Document.WordWrappedLines, codePane.Document.Selection);
+        var highlightedLines = CellRenderer.ApplyColorToCharacters(highlights, codePane.WordWrappedLines, codePane.Selection);
         // if we've filled up the full line, add a new line at the end so we can render our cursor on this new line.
         if (highlightedLines[^1].Cells.Count > 0
             && (highlightedLines[^1].Cells.Count >= codePane.CodeAreaWidth

--- a/src/PrettyPrompt/TextSelection/SelectionKeyPressHandler.cs
+++ b/src/PrettyPrompt/TextSelection/SelectionKeyPressHandler.cs
@@ -7,7 +7,7 @@
 using System;
 using System.Threading.Tasks;
 using PrettyPrompt.Consoles;
-using PrettyPrompt.Documents;
+using PrettyPrompt.Panes;
 using static System.ConsoleKey;
 using static System.ConsoleModifiers;
 
@@ -15,21 +15,21 @@ namespace PrettyPrompt.TextSelection;
 
 class SelectionKeyPressHandler : IKeyPressHandler
 {
-    private readonly Document document;
+    private readonly CodePane codePane;
     private ConsoleCoordinate previousCursorLocation;
 
-    public SelectionKeyPressHandler(Document document)
+    public SelectionKeyPressHandler(CodePane codePane)
     {
-        this.document = document;
+        this.codePane = codePane;
     }
 
     public Task OnKeyDown(KeyPress key)
     {
-        this.previousCursorLocation = document.Cursor;
+        this.previousCursorLocation = codePane.Cursor;
 
         if (key.Pattern is (Control, A))
         {
-            document.Caret = document.Length;
+            codePane.Document.Caret = codePane.Document.Length;
         }
         return Task.CompletedTask;
     }
@@ -46,15 +46,15 @@ class SelectionKeyPressHandler : IKeyPressHandler
         if (key.Pattern is (Control, A))
         {
             var start = ConsoleCoordinate.Zero;
-            var end = new ConsoleCoordinate(document.WordWrappedLines.Count - 1, document.WordWrappedLines[^1].Content.Length);
+            var end = new ConsoleCoordinate(codePane.WordWrappedLines.Count - 1, codePane.WordWrappedLines[^1].Content.Length);
             if (start < end)
             {
-                document.Selection = new SelectionSpan(start, end, SelectionDirection.FromLeftToRight);
+                codePane.Selection = new SelectionSpan(start, end, SelectionDirection.FromLeftToRight);
             }
             return Task.CompletedTask;
         }
 
-        var cursor = document.Cursor;
+        var cursor = codePane.Cursor;
         switch (key.Pattern)
         {
             case
@@ -89,7 +89,7 @@ class SelectionKeyPressHandler : IKeyPressHandler
 
             default:
                 // keypress is not related to selection
-                document.Selection = null;
+                codePane.Selection = null;
                 break;
         }
 
@@ -97,13 +97,13 @@ class SelectionKeyPressHandler : IKeyPressHandler
 
         void UpdateSelection(SelectionSpan newSelection)
         {
-            if (document.Selection.TryGet(out var selection))
+            if (codePane.Selection.TryGet(out var selection))
             {
-                document.Selection = selection.GetUpdatedSelection(newSelection);
+                codePane.Selection = selection.GetUpdatedSelection(newSelection);
             }
             else
             {
-                document.Selection = newSelection;
+                codePane.Selection = newSelection;
             }
         }
     }


### PR DESCRIPTION
This was motivated primarily by NRT and problems around WordWrappedLines which weren't set until WordWrap was called.