### PR TITLE
Completion insertion fixes. Resolves #65.

### DIFF
--- a/examples/PrettyPrompt.Examples.FruitPrompt/Program.cs
+++ b/examples/PrettyPrompt.Examples.FruitPrompt/Program.cs
@@ -74,18 +74,9 @@ internal static class Program
         };
 
     // demo completion algorithm callback
-    private static Task<IReadOnlyList<CompletionItem>> FindCompletions(string typedInput, int caret)
+    private static Task<IReadOnlyList<CompletionItem>> FindCompletions(string typedInput, int caret, TextSpan spanToBeReplaced)
     {
-        var nonWordChars = new[] { ' ', '\n', '.', '(', ')' };
-
-        var wordStart = typedInput.AsSpan(0, caret).LastIndexOfAny(nonWordChars);
-        wordStart = wordStart >= 0 ? wordStart + 1 : 0;
-
-        var wordEnd = typedInput.AsSpan(caret).IndexOfAny(nonWordChars);
-        wordEnd = wordEnd >= 0 ? wordEnd : typedInput.Length;
-
-        var typedWord = typedInput.AsSpan(wordStart, wordEnd - wordStart).ToString();
-
+        var typedWord = typedInput.AsSpan(spanToBeReplaced.Start, spanToBeReplaced.Length).ToString();
         return Task.FromResult<IReadOnlyList<CompletionItem>>(
             Fruits
             .Where(fruit => fruit.Name.StartsWith(typedWord, StringComparison.InvariantCultureIgnoreCase))

--- a/src/PrettyPrompt/Completion/CompletionItem.cs
+++ b/src/PrettyPrompt/Completion/CompletionItem.cs
@@ -16,11 +16,6 @@ namespace PrettyPrompt.Completion;
 public class CompletionItem
 {
     /// <summary>
-    /// The start index of the text that should be replaced
-    /// </summary>
-    public int StartIndex { get; }
-
-    /// <summary>
     /// When the completion item is selected, this text will be inserted into the document at the specified start index.
     /// </summary>
     public string ReplacementText { get; }
@@ -35,13 +30,11 @@ public class CompletionItem
     /// </summary>
     public Lazy<Task<FormattedString>>? ExtendedDescription { get; }
 
-    /// <param name="startIndex">The start index of the text that should be replaced</param>
     /// <param name="replacementText">When the completion item is selected, this text will be inserted into the document at the specified start index.</param>
     /// <param name="displayText">This text will be displayed in the completion menu. If not specified, the replacement text will be used.</param>
     /// <param name="extendedDescription">This lazy task will be executed when the item is selected, to display the extended "tool tip" description to the right of the menu.</param>
-    public CompletionItem(int startIndex, string replacementText, FormattedString displayText, Lazy<Task<FormattedString>>? extendedDescription)
+    public CompletionItem(string replacementText, FormattedString displayText, Lazy<Task<FormattedString>>? extendedDescription)
     {
-        StartIndex = startIndex;
         ReplacementText = replacementText;
         DisplayText = displayText;
         ExtendedDescription = extendedDescription;

--- a/src/PrettyPrompt/Completion/SlidingArrayWindow.cs
+++ b/src/PrettyPrompt/Completion/SlidingArrayWindow.cs
@@ -38,7 +38,7 @@ sealed class SlidingArrayWindow<T> : IReadOnlyCollection<T>
     /// <summary>
     /// Is not null when IsEmpty==false.
     /// </summary>
-    public T? SelectedItem =>        array.Length == 0 ? default : array[selectedIndex];
+    public T? SelectedItem => array.Length == 0 ? default : array[selectedIndex];
 
     public void IncrementSelectedIndex()
     {

--- a/src/PrettyPrompt/Documents/Document.cs
+++ b/src/PrettyPrompt/Documents/Document.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Text;
 
 namespace PrettyPrompt.Documents;
@@ -44,38 +43,40 @@ internal class Document : IEquatable<Document>
         this.undoRedoHistory = new UndoRedoHistory();
     }
 
-    public void InsertAtCaret(char character, (int Start, int End)? selection)
+    public void InsertAtCaret(char character, TextSpan? selection)
     {
         undoRedoHistory.Track(this);
         if (selection.TryGet(out var selectionValue))
         {
-            DeleteSelectedText(selectionValue.Start, selectionValue.End);
+            DeleteSelectedText(selectionValue);
         }
         text.Insert(Caret, character);
         Caret++;
         undoRedoHistory.Track(this);
     }
 
-    public void DeleteSelectedText(int start, int end)
+    public void DeleteSelectedText(TextSpan span)
     {
         undoRedoHistory.Track(this);
-        text.Remove(start, end - start);
+        text.Remove(span.Start, span.End - span.Start);
 
-        Caret = start;
+        Caret = span.Start;
         undoRedoHistory.Track(this);
     }
 
-    public void InsertAtCaret(string text, (int Start, int End)? selection)
+    public void InsertAtCaret(string text, TextSpan? selection)
     {
         undoRedoHistory.Track(this);
         if (selection.TryGet(out var selectionValue))
         {
-            DeleteSelectedText(selectionValue.Start, selectionValue.End);
+            DeleteSelectedText(selectionValue);
         }
         this.text.Insert(Caret, text);
         Caret += text.Length;
         undoRedoHistory.Track(this);
     }
+
+    public void Remove(TextSpan span) => Remove(span.Start, span.Length);
 
     public void Remove(int startIndex, int length)
     {
@@ -221,9 +222,9 @@ internal class Document : IEquatable<Document>
     public char this[int index] => this.text[index];
     public int Length => this.text.Length;
     public string GetText() => this.text.ToString();
+    public string GetText(TextSpan span) => GetText(span.Start, span.Length);
     public string GetText(int startIndex, int length) => this.text.ToString(startIndex, length);
-    public bool StartsWith(string prefix) =>
-        prefix.Length <= this.text.Length && this.text.ToString(0, prefix.Length).Equals(prefix);
+    public bool StartsWith(string prefix) => prefix.Length <= this.text.Length && this.text.ToString(0, prefix.Length).Equals(prefix);
     public override bool Equals(object? obj) => Equals(obj as Document);
     public bool Equals(Document? other) => other != null && other.text.Equals(this.text);
     public override int GetHashCode() => this.text.GetHashCode();

--- a/src/PrettyPrompt/Panes/CodePane.cs
+++ b/src/PrettyPrompt/Panes/CodePane.cs
@@ -161,7 +161,7 @@ internal class CodePane : IKeyPressHandler
                 break;
             case (_, Delete) or (_, Backspace) or Delete or Backspace when selection.TryGet(out var selectionValue):
                 {
-                    Document.DeleteSelectedText(selectionValue.Start, selectionValue.End);
+                    Document.DeleteSelectedText(selectionValue);
                 }
                 break;
             case Tab:
@@ -169,8 +169,8 @@ internal class CodePane : IKeyPressHandler
                 break;
             case (Control, X) when selection.TryGet(out var selectionValue):
                 {
-                    var cutContent = Document.GetText(selectionValue.Start, selectionValue.End - selectionValue.Start);
-                    Document.Remove(selectionValue.Start, selectionValue.End - selectionValue.Start);
+                    var cutContent = Document.GetText(selectionValue);
+                    Document.Remove(selectionValue);
                     await ClipboardService.SetTextAsync(cutContent);
                     break;
                 }
@@ -181,7 +181,7 @@ internal class CodePane : IKeyPressHandler
                 }
             case (Control, C) when selection.TryGet(out var selectionValue):
                 {
-                    var copiedContent = Document.GetText(selectionValue.Start, selectionValue.End - selectionValue.Start);
+                    var copiedContent = Document.GetText(selectionValue);
                     await ClipboardService.SetTextAsync(copiedContent);
                     break;
                 }
@@ -214,9 +214,9 @@ internal class CodePane : IKeyPressHandler
         }
     }
 
-    public (int Start, int End)? GetSelectionStartEnd()
+    public TextSpan? GetSelectionStartEnd()
     {
-        return Selection.TryGet(out var selectionSpanValue) ? selectionSpanValue.GetCaretIndices(WordWrappedLines) : default((int Start, int End)?);
+        return Selection.TryGet(out var selectionSpanValue) ? selectionSpanValue.GetCaretIndices(WordWrappedLines) : default(TextSpan?);
     }
 
     private void PasteText(string? pastedText)

--- a/src/PrettyPrompt/Panes/CompletionPane.cs
+++ b/src/PrettyPrompt/Panes/CompletionPane.cs
@@ -275,9 +275,9 @@ internal class CompletionPane : IKeyPressHandler
 
     private void InsertCompletion(Document input, CompletionItem completion, string suffix = "")
     {
-        input.Remove(completion.StartIndex, input.Caret - completion.StartIndex);
-        input.InsertAtCaret(completion.ReplacementText + suffix, codePane.GetSelectionStartEnd());
-        input.Caret = completion.StartIndex + completion.ReplacementText.Length + suffix.Length;
+        input.Remove(completion.StartIndex, Math.Min(completion.ReplacementText.Length, input.Length - completion.StartIndex));
+        input.InsertAtCaret(completion.ReplacementText, codePane.GetSelectionStartEnd());
+        input.Caret = completion.StartIndex + completion.ReplacementText.Length;
         Close();
     }
 }

--- a/src/PrettyPrompt/Panes/CompletionPane.cs
+++ b/src/PrettyPrompt/Panes/CompletionPane.cs
@@ -37,6 +37,7 @@ internal class CompletionPane : IKeyPressHandler
     private readonly CodePane codePane;
     private readonly CompletionCallbackAsync complete;
     private readonly OpenCompletionWindowCallbackAsync? shouldOpenCompletionWindow;
+    private readonly SpanToReplaceByCompletionCallbackAsync getSpanToReplaceByCompletion;
     private readonly int minCompletionItemsCount;
     private readonly int maxCompletionItemsCount;
 
@@ -64,12 +65,14 @@ internal class CompletionPane : IKeyPressHandler
         CodePane codePane,
         CompletionCallbackAsync complete,
         OpenCompletionWindowCallbackAsync? shouldOpenCompletionWindow,
+        SpanToReplaceByCompletionCallbackAsync getSpanToReplaceByCompletion,
         int minCompletionItemsCount,
         int maxCompletionItemsCount)
     {
         this.codePane = codePane;
         this.complete = complete;
         this.shouldOpenCompletionWindow = shouldOpenCompletionWindow;
+        this.getSpanToReplaceByCompletion = getSpanToReplaceByCompletion;
         this.minCompletionItemsCount = minCompletionItemsCount;
         this.maxCompletionItemsCount = maxCompletionItemsCount;
     }
@@ -88,9 +91,9 @@ internal class CompletionPane : IKeyPressHandler
         this.FilteredView = new SlidingArrayWindow<CompletionItem>();
     }
 
-    Task IKeyPressHandler.OnKeyDown(KeyPress key)
+    async Task IKeyPressHandler.OnKeyDown(KeyPress key)
     {
-        if (!EnoughRoomToDisplay(this.codePane)) return Task.CompletedTask;
+        if (!EnoughRoomToDisplay(this.codePane)) return;
 
         if (!IsOpen)
         {
@@ -98,16 +101,16 @@ internal class CompletionPane : IKeyPressHandler
             {
                 Open(codePane.Document.Caret);
                 key.Handled = true;
-                return Task.CompletedTask;
+                return;
             }
             key.Handled = false;
-            return Task.CompletedTask;
+            return;
         }
 
         if (FilteredView is null || FilteredView.Count == 0)
         {
             key.Handled = false;
-            return Task.CompletedTask;
+            return;
         }
 
         switch (key.Pattern)
@@ -125,7 +128,7 @@ internal class CompletionPane : IKeyPressHandler
             case Tab:
             case (Control, Spacebar) when FilteredView.Count == 1:
                 Debug.Assert(!FilteredView.IsEmpty);
-                InsertCompletion(codePane.Document, FilteredView.SelectedItem);
+                await InsertCompletion(codePane.Document, FilteredView.SelectedItem).ConfigureAwait(false);
                 key.Handled = true;
                 break;
             case (Control, Spacebar):
@@ -149,7 +152,7 @@ internal class CompletionPane : IKeyPressHandler
                 break;
         }
 
-        return Task.CompletedTask;
+        return;
     }
 
     private bool EnoughRoomToDisplay(CodePane codePane) =>
@@ -159,11 +162,11 @@ internal class CompletionPane : IKeyPressHandler
     {
         if (!EnoughRoomToDisplay(this.codePane)) return;
 
-        if (!char.IsControl(key.ConsoleKeyInfo.KeyChar)
-            && (await ShouldAutomaticallyOpen(codePane.Document, codePane.Document.Caret)) is int offset and >= 0)
+        if (!char.IsControl(key.ConsoleKeyInfo.KeyChar) &&
+            await ShouldAutomaticallyOpen(codePane.Document, codePane.Document.Caret).ConfigureAwait(false))
         {
             Close();
-            Open(codePane.Document.Caret - offset);
+            Open(codePane.Document.Caret);
         }
 
         if (codePane.Document.Caret < openedCaretIndex)
@@ -172,12 +175,14 @@ internal class CompletionPane : IKeyPressHandler
         }
         else if (IsOpen)
         {
+            var documentText = codePane.Document.GetText();
+            int documentCaret = codePane.Document.Caret;
             if (allCompletions.Count == 0)
             {
-                var completions = await this.complete.Invoke(codePane.Document.GetText(), codePane.Document.Caret).ConfigureAwait(false);
+                var completions = await complete.Invoke(documentText, documentCaret).ConfigureAwait(false);
                 if (completions.Any())
                 {
-                    SetCompletions(completions, codePane);
+                    await SetCompletions(documentText, documentCaret, completions, codePane).ConfigureAwait(false);
                 }
                 else
                 {
@@ -186,36 +191,37 @@ internal class CompletionPane : IKeyPressHandler
             }
             else if (!key.Handled)
             {
-                FilterCompletions(codePane);
+                _ = await FilterCompletions(documentText, documentCaret, codePane);
                 if (HasTypedPastCompletion() || ShouldCancelOpenMenu(key))
                 {
                     Close();
                 }
             }
         }
-    }
 
-    private bool HasTypedPastCompletion() =>
-        !FilteredView.IsEmpty
-        && FilteredView.SelectedItem.ReplacementText.Length < (codePane.Document.Caret - openedCaretIndex);
+        bool HasTypedPastCompletion() =>
+            !FilteredView.IsEmpty
+            && FilteredView.SelectedItem.ReplacementText.Length < (codePane.Document.Caret - openedCaretIndex);
+    }
 
     private static bool ShouldCancelOpenMenu(KeyPress key) =>
         key.Pattern is LeftArrow or (_, LeftArrow);
 
-    private void SetCompletions(IReadOnlyList<CompletionItem> completions, CodePane codePane)
+    private async Task SetCompletions(string documentText, int documentCaret, IReadOnlyList<CompletionItem> completions, CodePane codePane)
     {
         allCompletions = completions;
         if (completions.Any())
         {
-            openedCaretIndex = completions[0].StartIndex;
-            FilterCompletions(codePane);
+            var spanToReplace = await FilterCompletions(documentText, documentCaret, codePane);
+            openedCaretIndex = spanToReplace.Start;
         }
     }
 
-    private void FilterCompletions(CodePane codePane)
+    private async Task<TextSpan> FilterCompletions(string documentText, int documentCaret, CodePane codePane)
     {
+        var spanToReplace = await getSpanToReplaceByCompletion(documentText, documentCaret);
+        Debug.WriteLine(spanToReplace);
         int height = Math.Min(codePane.CodeAreaHeight - VerticalPaddingHeight, maxCompletionItemsCount);
-
         var filtered = new List<CompletionItem>();
         var previouslySelectedItem = this.FilteredView.SelectedItem;
         int selectedIndex = -1;
@@ -239,15 +245,16 @@ internal class CompletionPane : IKeyPressHandler
             height,
             selectedIndex
         );
+        return spanToReplace;
 
         bool Matches(CompletionItem? completion, Document input) =>
             completion?.ReplacementText.StartsWith(
-                input.GetText(completion.StartIndex, codePane.Document.Caret - completion.StartIndex).Trim(),
+                input.GetText(spanToReplace).Trim(),
                 StringComparison.CurrentCultureIgnoreCase
             ) ?? false;
     }
 
-    private Task<int> ShouldAutomaticallyOpen(Document input, int caret)
+    private Task<bool> ShouldAutomaticallyOpen(Document input, int caret)
     {
         if (shouldOpenCompletionWindow is not null)
         {
@@ -256,28 +263,29 @@ internal class CompletionPane : IKeyPressHandler
 
         if (caret > 0 && input[caret - 1] is '.' or '(') // typical "intellisense behavior", opens for new methods and parameters
         {
-            return Task.FromResult(0);
+            return Task.FromResult(true);
         }
 
         if (caret == 1 && !char.IsWhiteSpace(input[0]) // 1 word character typed in brand new prompt
             && (input.Length == 1 || !char.IsLetterOrDigit(input[1]))) // if there's more than one character on the prompt, but we're typing a new word at the beginning (e.g. "a| bar")
         {
-            return Task.FromResult(1);
+            return Task.FromResult(true);
         }
 
         // open when we're starting a new "word" in the prompt.
         return caret - 2 >= 0
             && char.IsWhiteSpace(input[caret - 2])
             && char.IsLetter(input[caret - 1])
-            ? Task.FromResult(1)
-            : Task.FromResult(-1);
+            ? Task.FromResult(true)
+            : Task.FromResult(false);
     }
 
-    private void InsertCompletion(Document input, CompletionItem completion, string suffix = "")
+    private async Task InsertCompletion(Document document, CompletionItem completion)
     {
-        input.Remove(completion.StartIndex, Math.Min(completion.ReplacementText.Length, input.Length - completion.StartIndex));
-        input.InsertAtCaret(completion.ReplacementText, codePane.GetSelectionStartEnd());
-        input.Caret = completion.StartIndex + completion.ReplacementText.Length;
+        var spanToReplace = await getSpanToReplaceByCompletion(document.GetText(), document.Caret).ConfigureAwait(false);
+        document.Remove(spanToReplace);
+        document.InsertAtCaret(completion.ReplacementText, codePane.GetSelectionStartEnd());
+        document.Caret = spanToReplace.Start + completion.ReplacementText.Length;
         Close();
     }
 }

--- a/src/PrettyPrompt/Prompt.cs
+++ b/src/PrettyPrompt/Prompt.cs
@@ -28,6 +28,7 @@ public sealed class Prompt : IPrompt
 
     private readonly CompletionCallbackAsync completionCallback;
     private readonly OpenCompletionWindowCallbackAsync? shouldOpenCompletionWindow;
+    private readonly SpanToReplaceByCompletionCallbackAsync getSpanToReplaceByCompletion;
     private readonly ForceSoftEnterCallbackAsync detectSoftEnterCallback;
     private readonly Dictionary<object, KeyPressCallbackAsync> keyPressCallbacks;
     private readonly SyntaxHighlighter highlighter;
@@ -55,6 +56,7 @@ public sealed class Prompt : IPrompt
         callbacks ??= new PromptCallbacks();
         this.completionCallback = callbacks.CompletionCallback;
         this.shouldOpenCompletionWindow = callbacks.OpenCompletionWindowCallback;
+        this.getSpanToReplaceByCompletion= callbacks.SpanToReplaceByCompletionCallback;
         this.detectSoftEnterCallback = callbacks.ForceSoftEnterCallback;
         this.keyPressCallbacks = callbacks.KeyPressCallbacks;
 
@@ -73,7 +75,13 @@ public sealed class Prompt : IPrompt
         codePane.MeasureConsole(console, configuration.Prompt);
 
         // completion pane is the pop-up window that shows potential autocompletions.
-        var completionPane = new CompletionPane(codePane, completionCallback, shouldOpenCompletionWindow, configuration.MinCompletionItemsCount, configuration.MaxCompletionItemsCount);
+        var completionPane = new CompletionPane(
+            codePane,
+            completionCallback,
+            shouldOpenCompletionWindow,
+            getSpanToReplaceByCompletion,
+            configuration.MinCompletionItemsCount,
+            configuration.MaxCompletionItemsCount);
 
         history.Track(codePane);
         cancellationManager.CaptureControlC();

--- a/src/PrettyPrompt/PromptCallbacks.cs
+++ b/src/PrettyPrompt/PromptCallbacks.cs
@@ -28,8 +28,9 @@ public delegate Task<TextSpan> SpanToReplaceByCompletionCallbackAsync(string tex
 /// </summary>
 /// <param name="text">The user's input text</param>
 /// <param name="caret">The index of the text caret in the input text</param>
+/// <param name="spanToBeReplaced">Span of text that will be replaced by inserted completion item</param>
 /// <returns>A list of possible completions that will be displayed in the autocomplete menu.</returns>
-public delegate Task<IReadOnlyList<CompletionItem>> CompletionCallbackAsync(string text, int caret);
+public delegate Task<IReadOnlyList<CompletionItem>> CompletionCallbackAsync(string text, int caret, TextSpan spanToBeReplaced);
 
 /// <summary>
 /// A callback your application can provide to determine whether or not the completion window
@@ -123,7 +124,7 @@ public class PromptCallbacks
     /// An optional delegate that provides autocompletion results.
     /// </summary>
     public CompletionCallbackAsync CompletionCallback { get; init; } =
-        (_, _) => Task.FromResult<IReadOnlyList<CompletionItem>>(Array.Empty<CompletionItem>());
+        (_, _, _) => Task.FromResult<IReadOnlyList<CompletionItem>>(Array.Empty<CompletionItem>());
 
     /// <summary>
     /// An optional delegate that controls when the completion window should open.

--- a/src/PrettyPrompt/TextSelection/SelectionSpan.cs
+++ b/src/PrettyPrompt/TextSelection/SelectionSpan.cs
@@ -35,7 +35,7 @@ internal readonly struct SelectionSpan
         Direction = direction;
     }
 
-    public (int Start, int End) GetCaretIndices(IReadOnlyList<WrappedLine> wrappedLines)
+    public TextSpan GetCaretIndices(IReadOnlyList<WrappedLine> wrappedLines)
     {
         Debug.Assert(Start.Column <= wrappedLines[Start.Row].Content.Length);
         //End.Row==wrappedLines.Count when last line ends with '\n' (-> End.Row is empty and not present in wrappedLines)
@@ -49,7 +49,7 @@ internal readonly struct SelectionSpan
             wrappedLines[End.Row - 1].StartIndex + wrappedLines[End.Row - 1].Content.Length;
 
         Debug.Assert(selectionStart < selectionEnd);
-        return (selectionStart, selectionEnd);
+        return TextSpan.FromBounds(selectionStart, selectionEnd);
     }
 
     public SelectionSpan WithStart(ConsoleCoordinate start) => new(start, End, Direction);

--- a/tests/PrettyPrompt.Tests/ChineseJapaneseKoreanTests.cs
+++ b/tests/PrettyPrompt.Tests/ChineseJapaneseKoreanTests.cs
@@ -64,7 +64,7 @@ public class ChineseJapaneseKoreanTests
 
         var prompt = new Prompt(console: console, callbacks: new PromptCallbacks
         {
-            CompletionCallback = new CompletionTestData(new[] { "书桌上有" }).CompletionHandlerAsync
+            CompletionCallback = new CompletionTestData("书桌上有").CompletionHandlerAsync
         });
         var result = await prompt.ReadLineAsync();
 

--- a/tests/PrettyPrompt.Tests/CompletionTestData.cs
+++ b/tests/PrettyPrompt.Tests/CompletionTestData.cs
@@ -4,12 +4,13 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #endregion
 
-using PrettyPrompt.Completion;
-using PrettyPrompt.Highlighting;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using PrettyPrompt.Completion;
+using PrettyPrompt.Documents;
+using PrettyPrompt.Highlighting;
 
 namespace PrettyPrompt.Tests;
 
@@ -17,23 +18,31 @@ public class CompletionTestData
 {
     private readonly IReadOnlyCollection<string> completions;
 
-    public CompletionTestData(IReadOnlyCollection<string>? completions = null)
+    public CompletionTestData()
+        : this(null)
+    { }
+
+    public CompletionTestData(params string[]? completions)
     {
         this.completions = completions ?? new[] { "Aardvark", "Albatross", "Alligator", "Alpaca", "Ant", "Anteater", "Baboon", "Cat", "Dog", "Elephant", "Fox", "Zebra" };
     }
 
-    public Task<IReadOnlyList<CompletionItem>> CompletionHandlerAsync(string text, int caret)
+    public Task<IReadOnlyList<CompletionItem>> CompletionHandlerAsync(string typedInput, int caret)
     {
-        var textUntilCaret = text.Substring(0, caret);
-        var previousWordStart = textUntilCaret.LastIndexOfAny(new[] { ' ', '\n', '.', '(', ')' });
-        var typedWord = previousWordStart == -1
-            ? textUntilCaret
-            : textUntilCaret.Substring(previousWordStart + 1);
+        var nonWordChars = new[] { ' ', '\n', '.', '(', ')' };
+
+        var wordStart = typedInput.AsSpan(0, caret).LastIndexOfAny(nonWordChars);
+        wordStart = wordStart >= 0 ? wordStart + 1 : 0;
+
+        var wordEnd = typedInput.AsSpan(caret).IndexOfAny(nonWordChars);
+        wordEnd = wordEnd >= 0 ? wordEnd : typedInput.Length;
+
+        var typedWord = typedInput.AsSpan(wordStart, wordEnd - wordStart).ToString();
+
         return Task.FromResult<IReadOnlyList<CompletionItem>>(
             completions
                 .Where(c => c.StartsWith(typedWord, StringComparison.CurrentCultureIgnoreCase))
                 .Select((c, i) => new CompletionItem(
-                    startIndex: previousWordStart + 1,
                     replacementText: c,
                     displayText: i % 2 == 0 ? c : null, // display text is optional, ReplacementText should be used when this is null.
                     extendedDescription: new Lazy<Task<FormattedString>>(() => Task.FromResult<FormattedString>("a vivid description of " + c))

--- a/tests/PrettyPrompt.Tests/CompletionTestData.cs
+++ b/tests/PrettyPrompt.Tests/CompletionTestData.cs
@@ -27,18 +27,9 @@ public class CompletionTestData
         this.completions = completions ?? new[] { "Aardvark", "Albatross", "Alligator", "Alpaca", "Ant", "Anteater", "Baboon", "Cat", "Dog", "Elephant", "Fox", "Zebra" };
     }
 
-    public Task<IReadOnlyList<CompletionItem>> CompletionHandlerAsync(string typedInput, int caret)
+    public Task<IReadOnlyList<CompletionItem>> CompletionHandlerAsync(string typedInput, int caret, TextSpan spanToBeReplaced)
     {
-        var nonWordChars = new[] { ' ', '\n', '.', '(', ')' };
-
-        var wordStart = typedInput.AsSpan(0, caret).LastIndexOfAny(nonWordChars);
-        wordStart = wordStart >= 0 ? wordStart + 1 : 0;
-
-        var wordEnd = typedInput.AsSpan(caret).IndexOfAny(nonWordChars);
-        wordEnd = wordEnd >= 0 ? wordEnd : typedInput.Length;
-
-        var typedWord = typedInput.AsSpan(wordStart, wordEnd - wordStart).ToString();
-
+        var typedWord = typedInput.AsSpan(spanToBeReplaced.Start, spanToBeReplaced.Length).ToString();
         return Task.FromResult<IReadOnlyList<CompletionItem>>(
             completions
                 .Where(c => c.StartsWith(typedWord, StringComparison.CurrentCultureIgnoreCase))

--- a/tests/PrettyPrompt.Tests/ConsoleStub.cs
+++ b/tests/PrettyPrompt.Tests/ConsoleStub.cs
@@ -165,6 +165,16 @@ public static class ConsoleStub
                 var parsed = char.TryParse(key.Value, out char character);
                 list.Add(consoleKey.ToKeyInfo(parsed ? character : MapSpecialKey(consoleKey), modifiersPressed));
                 return 0;
+            case string text:
+                if (text.Length > 0)
+                {
+                    list.Add(CharToConsoleKey(text[0]).ToKeyInfo(text[0], modifiersPressed));
+                }
+                for (int i = 1; i < text.Length; i++)
+                {
+                    list.Add(CharToConsoleKey(text[i]).ToKeyInfo(text[i], 0));
+                }
+                return 0;
             default: throw new ArgumentException("Unknown value: " + formatArgument, nameof(formatArgument));
         }
     }


### PR DESCRIPTION
This one was much more complicated than expected.

Main (breaking) changes:
- ```StartIndex``` is removed from ```CompletionItem```.
    - Originally I wanted (contrary to the final result) to extend ```CompletionItem``` by changing ```StartIndex``` to ```Span```. But that didn't play nicely with the current approach of generating completion items "once" and then filtering them.
- ```PromptCallbacks```
    - New callback ```Task<TextSpan> SpanToReplaceByCompletionCallback(string text, int caret)``` is added. It returns span of text that will be replaced by inserted completion item. There is default word detection implementation, so providing this callback is optional. In CSharpRepl we should use ```CompletionService.GetDefaultCompletionListSpan``` for this callback.
    - ```CompletionCallback``` has new parameter ```TextSpan spanToBeReplaced``` which is filled by ```SpanToReplaceByCompletionCallback```. This gratly simplifies implementation of this callback.
    - ```OpenCompletionWindowCallback``` returns ```bool``` instead of ```int```.