### PR TITLE
Cliboard mutex protection in unit tests fix.

### DIFF
--- a/src/PrettyPrompt/Console/IConsole.cs
+++ b/src/PrettyPrompt/Console/IConsole.cs
@@ -38,4 +38,5 @@ public interface IConsole
 internal interface IConsoleWithClipboard : IConsole
 {
     IClipboard Clipboard { get; }
+    IDisposable ProtectClipboard();
 }

--- a/tests/PrettyPrompt.Tests/PromptTests.cs
+++ b/tests/PrettyPrompt.Tests/PromptTests.cs
@@ -273,13 +273,16 @@ public class PromptTests
     public async Task ReadLine_PasteMultipleLines()
     {
         const string Text = "abc\r\ndef";
-        ClipboardService.SetText(Text);
         var console = ConsoleStub.NewConsole();
-        console.StubInput($"{Control}{V}{Enter}");
-        var prompt = new Prompt(console: console);
-        var result = await prompt.ReadLineAsync();
-        Assert.True(result.IsSuccess);
-        Assert.Equal(Text, result.Text);
+        using (console.ProtectClipboard())
+        {
+            console.Clipboard.SetText(Text);
+            console.StubInput($"{Control}{V}{Enter}");
+            var prompt = new Prompt(console: console);
+            var result = await prompt.ReadLineAsync();
+            Assert.True(result.IsSuccess);
+            Assert.Equal(Text, result.Text);
+        }
     }
 
     [Fact]

--- a/tests/PrettyPrompt.Tests/SelectionTests.cs
+++ b/tests/PrettyPrompt.Tests/SelectionTests.cs
@@ -127,34 +127,38 @@ public class SelectionTests
     public async Task ReadLine_CopiedText_CanBePasted()
     {
         var console = ConsoleStub.NewConsole();
-        console.StubInput(
-            $"baby shark doo",
-            $"{Control | Shift}{LeftArrow}{Shift}{LeftArrow}{Control}{C}{End}",
-            $"{Control}{V}{Control}{V}{Control}{V}{Enter}"
-        );
+        using (console.ProtectClipboard())
+        {
+            console.StubInput(
+                $"baby shark doo",
+                $"{Control | Shift}{LeftArrow}{Shift}{LeftArrow}{Control}{C}{End}",
+                $"{Control}{V}{Control}{V}{Control}{V}{Enter}");
 
-        var prompt = new Prompt(console: console);
-        var result = await prompt.ReadLineAsync();
+            var prompt = new Prompt(console: console);
+            var result = await prompt.ReadLineAsync();
 
-        Assert.True(result.IsSuccess);
-        Assert.Equal("baby shark doo doo doo doo", result.Text);
+            Assert.True(result.IsSuccess);
+            Assert.Equal("baby shark doo doo doo doo", result.Text);
+        }
     }
 
     [Fact]
     public async Task ReadLine_CutText_CanBePasted()
     {
         var console = ConsoleStub.NewConsole();
-        console.StubInput(
-            $"baby shark doo doo doo doo",
-            $"{Home}{Control | Shift}{RightArrow}{Control | Shift}{RightArrow}{Shift}{LeftArrow}",
-            $"{Control}{X}{Delete}{End} {Control}{V}{Enter}"
-        );
+        using (console.ProtectClipboard())
+        {
+            console.StubInput(
+                $"baby shark doo doo doo doo",
+                $"{Home}{Control | Shift}{RightArrow}{Control | Shift}{RightArrow}{Shift}{LeftArrow}",
+                $"{Control}{X}{Delete}{End} {Control}{V}{Enter}");
 
-        var prompt = new Prompt(console: console);
-        var result = await prompt.ReadLineAsync();
+            var prompt = new Prompt(console: console);
+            var result = await prompt.ReadLineAsync();
 
-        Assert.True(result.IsSuccess);
-        Assert.Equal("doo doo doo doo baby shark", result.Text);
+            Assert.True(result.IsSuccess);
+            Assert.Equal("doo doo doo doo baby shark", result.Text);
+        }
     }
 
     [Fact]

--- a/tests/PrettyPrompt.Tests/UndoRedoTests.cs
+++ b/tests/PrettyPrompt.Tests/UndoRedoTests.cs
@@ -5,7 +5,6 @@
 #endregion
 
 using System.Threading.Tasks;
-using TextCopy;
 using Xunit;
 using static System.ConsoleKey;
 using static System.ConsoleModifiers;
@@ -254,18 +253,21 @@ public class UndoRedoTests
 
         //---------------------------------------------
 
-        ClipboardService.SetText("xyz");
         console = ConsoleStub.NewConsole();
-        console.StubInput(
-            $"abcd",
-            $"{LeftArrow}{Shift}{LeftArrow}{Shift}{LeftArrow}", //select 'bc'
-            $"{Control}{V}", //paste 'xyz' (=replace 'bc' with 'xyz')
-            $"{Control}{Z}", //redo
-            $"{Enter}"
-        );
-        prompt = new Prompt(console: console);
-        result = await prompt.ReadLineAsync();
-        Assert.True(result.IsSuccess);
-        Assert.Equal("abcd", result.Text);
+        using (console.ProtectClipboard())
+        {
+            console.Clipboard.SetText("xyz");
+            console.StubInput(
+                $"abcd",
+                $"{LeftArrow}{Shift}{LeftArrow}{Shift}{LeftArrow}", //select 'bc'
+                $"{Control}{V}", //paste 'xyz' (=replace 'bc' with 'xyz')
+                $"{Control}{Z}", //redo
+                $"{Enter}"
+            );
+            prompt = new Prompt(console: console);
+            result = await prompt.ReadLineAsync();
+            Assert.True(result.IsSuccess);
+            Assert.Equal("abcd", result.Text);
+        }
     }
 }


### PR DESCRIPTION
The previous attempt (#74) to fix this issue was incorrect. It was protecting just copy/paste calls which is of course insufficient.
Now unit tests can protect the clipboard for an arbitrary region of code with:
```C#
using (console.ProtectClipboard())
{
    //code with a protected clipboard
    //while in this region no other thread can use clipboard
}
```
This assumes that all unit tests that want to interact with the clipboard uses ```console.Clipboard``` (available only in unit tests).