### PR TITLE
Word wrapping asserts + bug fix

### DIFF
--- a/src/PrettyPrompt/Documents/Document.cs
+++ b/src/PrettyPrompt/Documents/Document.cs
@@ -206,17 +206,3 @@ internal class Document : IEquatable<Document>
     public override int GetHashCode() => this.stringBuilder.GetHashCode();
     private string GetDebuggerDisplay() => this.stringBuilder.ToString().Insert(this.Caret, "|");
 }
-
-internal readonly struct WrappedLine
-{
-    public readonly int StartIndex;
-    public readonly string Content;
-
-    public WrappedLine(int startIndex, string content)
-    {
-        Debug.Assert(startIndex >= 0);
-
-        StartIndex = startIndex;
-        Content = content;
-    }
-}


### PR DESCRIPTION
Asserts found bug in WrapEditableCharacters when it could return fewer lines than cursor was pointing to.