### PR TITLE
Automatic word wrapping and cursor position updating. Resolves #68.

### DIFF
--- a/src/PrettyPrompt/Documents/UndoRedoHistory.cs
+++ b/src/PrettyPrompt/Documents/UndoRedoHistory.cs
@@ -22,16 +22,16 @@ internal sealed class UndoRedoHistory
     private readonly List<StringBuilderWithCaret> history = new();
     private int currentIndex;
 
-    public UndoRedoHistory(StringBuilderWithCaret document)
+    public UndoRedoHistory(StringBuilderWithCaret text)
     {
-        history.Add(document.Clone());
+        history.Add(text.Clone());
     }
 
-    internal TrackingOperation Track(StringBuilderWithCaret document)
+    internal void Track(StringBuilderWithCaret text)
     {
         CheckValidity();
 
-        if (!history[currentIndex].EqualsText(document))
+        if (!history[currentIndex].EqualsText(text))
         {
             if (currentIndex != history.Count - 1)
 
@@ -41,10 +41,9 @@ internal sealed class UndoRedoHistory
                 history.RemoveRange(1, itemsToRemove);
             }
 
-            history.Add(document.Clone());
+            history.Add(text.Clone());
             currentIndex = history.Count - 1;
         }
-        return new TrackingOperation(this, document);
     }
 
     public StringBuilderWithCaret Undo()
@@ -83,22 +82,5 @@ internal sealed class UndoRedoHistory
     {
         Debug.Assert(history.Count > 0);
         Debug.Assert(currentIndex >= 0 && currentIndex < history.Count);
-    }
-
-    public readonly struct TrackingOperation : IDisposable
-    {
-        private readonly UndoRedoHistory history;
-        private readonly StringBuilderWithCaret document;
-
-        public TrackingOperation(UndoRedoHistory history, StringBuilderWithCaret document)
-        {
-            this.history = history;
-            this.document = document;
-        }
-
-        public void Dispose()
-        {
-            history.Track(document);
-        }
     }
 }

--- a/src/PrettyPrompt/History/HistoryLog.cs
+++ b/src/PrettyPrompt/History/HistoryLog.cs
@@ -156,9 +156,7 @@ sealed class HistoryLog : IKeyPressHandler
     {
         if (codepane.Document.Equals(contents)) return;
 
-        codepane.Document.Clear();
-        codepane.Document.InsertAtCaret(contents.GetText(), codepane.GetSelectionSpan());
-        codepane.WordWrap();
+        codepane.Document.SetContents(contents);
     }
 
     internal void Track(CodePane codePane)

--- a/src/PrettyPrompt/Panes/CodePane.cs
+++ b/src/PrettyPrompt/Panes/CodePane.cs
@@ -7,7 +7,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using PrettyPrompt.Consoles;
@@ -94,9 +93,12 @@ internal class CodePane : IKeyPressHandler
         this.shouldForceSoftEnterAsync = shouldForceSoftEnterAsync;
         this.clipboard = clipboard;
         this.Document = new Document();
+        this.Document.Changed += WordWrap;
         this.selectionHandler = new SelectionKeyPressHandler(this);
 
         WordWrap();
+
+        void WordWrap() => wordWrappedText = Document.WrapEditableCharacters(CodeAreaWidth);
     }
 
     public async Task OnKeyDown(KeyPress key)
@@ -206,11 +208,9 @@ internal class CodePane : IKeyPressHandler
                 break;
             case (Control, Z):
                 Document.Undo();
-                WordWrap();
                 break;
             case (Control, Y):
                 Document.Redo();
-                WordWrap();
                 break;
             default:
                 if (!char.IsControl(key.ConsoleKeyInfo.KeyChar))
@@ -281,11 +281,6 @@ internal class CodePane : IKeyPressHandler
         await selectionHandler.OnKeyUp(key).ConfigureAwait(false);
 
         CheckConsistency();
-    }
-
-    public void WordWrap()
-    {
-        wordWrappedText = Document.WrapEditableCharacters(CodeAreaWidth);
     }
 
     /// <summary>

--- a/src/PrettyPrompt/Panes/CompletionPane.cs
+++ b/src/PrettyPrompt/Panes/CompletionPane.cs
@@ -283,6 +283,7 @@ internal class CompletionPane : IKeyPressHandler
     {
         var spanToReplace = await getSpanToReplaceByCompletion(document.GetText(), document.Caret).ConfigureAwait(false);
         document.Remove(spanToReplace);
+        codePane.Selection = null;
         document.InsertAtCaret(completion.ReplacementText, codePane.GetSelectionSpan());
         document.Caret = spanToReplace.Start + completion.ReplacementText.Length;
         Close();

--- a/src/PrettyPrompt/Prompt.cs
+++ b/src/PrettyPrompt/Prompt.cs
@@ -125,8 +125,6 @@ public sealed class Prompt : IPrompt
         foreach (var panes in new IKeyPressHandler[] { completionPane, codePane, history })
             await panes.OnKeyDown(key).ConfigureAwait(false);
 
-        codePane.WordWrap();
-
         foreach (var panes in new IKeyPressHandler[] { completionPane, codePane, history })
             await panes.OnKeyUp(key).ConfigureAwait(false);
     }

--- a/tests/PrettyPrompt.Tests/FuzzingTests.cs
+++ b/tests/PrettyPrompt.Tests/FuzzingTests.cs
@@ -69,9 +69,9 @@ public class FuzzingTests
             )
             .Concat(new[]
             {
-                    A.ToKeyInfo('a'),
-                    Enter.ToKeyInfo('\0', shift: true),
-                    Delete.ToKeyInfo('\0')
+                A.ToKeyInfo('a'),
+                Enter.ToKeyInfo('\0', shift: true),
+                Delete.ToKeyInfo('\0')
             })
             .ToArray();
 
@@ -84,6 +84,58 @@ public class FuzzingTests
         console.StubInput(randomKeys);
 
         var prompt = new Prompt(persistentHistoryFilepath: Path.GetTempFileName(), console: console);
+
+        try
+        {
+            var result = await prompt.ReadLineAsync();
+            Assert.NotNull(result);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException("Fuzzing failed for seed: " + seed, ex);
+        }
+    }
+
+    [Theory(Timeout = 60 * 1000)]
+    [InlineData(null)] // random seed, if we find other failing seeds, we can add them here as additional cases
+    [InlineData(1)] // triggered https://github.com/waf/PrettyPrompt/issues/68
+    public async Task FuzzedSelectionAndCompletion(int? seed)
+    {
+        seed ??= Guid.NewGuid().GetHashCode();
+        var r = new Random(seed.Value);
+
+        var directions = new[] { Home, End, LeftArrow, RightArrow, UpArrow, DownArrow };
+        var keySet =
+            (
+                from ctrl in new[] { false, true }
+                from shift in new[] { false, true }
+                from key in directions
+                select key.ToKeyInfo('\0', shift: shift, control: ctrl)
+            )
+            .Concat(new[]
+            {
+                A.ToKeyInfo('a'),
+                Enter.ToKeyInfo('\0', shift: true),
+                Delete.ToKeyInfo('\0'),
+                Spacebar.ToKeyInfo('\0', control: true), //completion trigger
+            })
+            .ToArray();
+
+        var randomKeys = Enumerable.Range(1, 10_000)
+            .Select(_ => keySet[r.Next(keySet.Length)])
+            .Concat(Enumerable.Repeat(Enter.ToKeyInfo('\0'), 4)) // hit enter a few times to submit the prompt
+            .ToList();
+
+        var console = ConsoleStub.NewConsole();
+        console.StubInput(randomKeys);
+
+        var prompt = new Prompt(
+            persistentHistoryFilepath: Path.GetTempFileName(),
+            callbacks: new PromptCallbacks
+            {
+                CompletionCallback = new CompletionTestData(null).CompletionHandlerAsync
+            },
+            console: console);
 
         try
         {

--- a/tests/PrettyPrompt.Tests/SelectionTests.cs
+++ b/tests/PrettyPrompt.Tests/SelectionTests.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using PrettyPrompt.Consoles;
 using Xunit;
 using static System.ConsoleKey;
 using static System.ConsoleModifiers;
@@ -407,9 +408,7 @@ public class SelectionTests
             $"{Control}{Enter}"); //confirm input
 
         var prompt = new Prompt(console: console);
-
         var result = await prompt.ReadLineAsync();
-
         Assert.True(result.IsSuccess);
 
         var output = console.GetAllOutput();
@@ -419,5 +418,23 @@ public class SelectionTests
         Assert.Contains("456", redraw);
         Assert.Contains("789", redraw);
         Assert.DoesNotContain("7m", redraw); //reverse
+    }
+
+    [Fact]
+    public async Task ReadLine_WriteLetter_LeftSelect_OverWrite_CheckRedraw()
+    {
+        var console = ConsoleStub.NewConsole();
+        var prompt = new Prompt(console: console);
+        console.StubInput(
+            $"a",
+            $"{Shift}{LeftArrow}b",
+            $"{Enter}"
+        );
+        var result = await prompt.ReadLineAsync();
+        Assert.True(result.IsSuccess);
+        var outputs = console.GetAllOutput();
+        Assert.Equal("a", outputs[1]);
+        Assert.Equal("\u001b[1D\u001b[39;49;7ma\u001b[0m\u001b[1D", outputs[2]); //move left, rewrite 'a' with reverse colors, reset, move left
+        Assert.Equal("b", outputs[3]);
     }
 }


### PR DESCRIPTION
It was necessary to manually call ```CodePane.WordWrap``` on a lot of places to guarantee consistency of ```Document```'s content/caret and ```CodePane```'s WrappedLines/Cursor. Now, this happens automatically.

This also fixes bug #68.