### PR TITLE
Handling of tabs and special character in pasted text

### DIFF
--- a/src/PrettyPrompt/Documents/Document.cs
+++ b/src/PrettyPrompt/Documents/Document.cs
@@ -16,6 +16,8 @@ namespace PrettyPrompt.Documents;
 [DebuggerDisplay("{" + nameof(GetDebuggerDisplay) + "(),nq}")]
 internal class Document : IEquatable<Document>
 {
+    public const string TabSpaces = "    ";
+
     private readonly StringBuilderWithCaret stringBuilder;
     private readonly UndoRedoHistory undoRedoHistory;
 

--- a/src/PrettyPrompt/Documents/WordWrapping.cs
+++ b/src/PrettyPrompt/Documents/WordWrapping.cs
@@ -46,7 +46,14 @@ internal static class WordWrapping
                 line.Append(character);
                 bool isCursorPastCharacter = initialCaretPosition > textIndex;
 
-                currentLineLength += UnicodeWidth.GetWidth(character);
+                Debug.Assert(character != '\t', "tabs should be replaced by spaces");
+                int unicodeWidth = UnicodeWidth.GetWidth(character);
+                if (unicodeWidth < 1)
+                {
+                    Debug.Fail("such character should not be present");
+                    continue;
+                }
+                currentLineLength += unicodeWidth;
                 textIndex++;
 
                 if (isCursorPastCharacter && !char.IsControl(character))

--- a/tests/PrettyPrompt.Tests/PromptTests.cs
+++ b/tests/PrettyPrompt.Tests/PromptTests.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NSubstitute;
+using PrettyPrompt.Documents;
 using PrettyPrompt.Highlighting;
 using TextCopy;
 using Xunit;
@@ -168,7 +169,7 @@ public class PromptTests
         var prompt = new Prompt(console: console);
         var result = await prompt.ReadLineAsync();
 
-        Assert.Equal($"aaaa bbbb 5555{NewLine}dddd x5x5    foo.lumbar{NewLine}", result.Text);
+        Assert.Equal($"aaaa bbbb 5555{NewLine}dddd x5x5{Document.TabSpaces}foo.lumbar{NewLine}", result.Text);
     }
 
     [Fact]
@@ -268,7 +269,6 @@ public class PromptTests
     /// <summary>
     /// Triggered issue: https://github.com/waf/PrettyPrompt/issues/63
     /// </summary>
-    /// <returns></returns>
     [Fact]
     public async Task ReadLine_PasteMultipleLines()
     {
@@ -282,6 +282,24 @@ public class PromptTests
             var result = await prompt.ReadLineAsync();
             Assert.True(result.IsSuccess);
             Assert.Equal(Text, result.Text);
+        }
+    }
+
+    /// <summary>
+    /// Triggered issue: https://github.com/waf/PrettyPrompt/issues/55
+    /// </summary>
+    [Fact]
+    public async Task ReadLine_PasteTabWithChar()
+    {
+        var console = ConsoleStub.NewConsole();
+        using (console.ProtectClipboard())
+        {
+            console.Clipboard.SetText("\ta");
+            console.StubInput($"{Control}{V}{Enter}");
+            var prompt = new Prompt(console: console);
+            var result = await prompt.ReadLineAsync();
+            Assert.True(result.IsSuccess);
+            Assert.Equal($"{Document.TabSpaces}a", result.Text);
         }
     }
 


### PR DESCRIPTION
Tabs are replaced by spaces when present in the pasted text. Special (=unicodeWidth < 1) chars are filtered out of the pasted text. WrapEditableCharacters ignores such characters and checks with asserts that they are not present.

Resolves #55.