### PR TITLE
Configurable newline and prompt submit key bindings.

### DIFF
--- a/examples/PrettyPrompt.Examples.FruitPrompt/Program.cs
+++ b/examples/PrettyPrompt.Examples.FruitPrompt/Program.cs
@@ -31,7 +31,7 @@ internal static class Program
                 if (response.Text == "exit") break;
                 // optionally, use response.CancellationToken so the user can
                 // cancel long-running processing of their response via ctrl-c
-                Console.WriteLine("You wrote " + (response.IsHardEnter ? response.Text.ToUpper() : response.Text));
+                Console.WriteLine("You wrote " + (response.SubmitPattern.Modifiers.HasFlag(ConsoleModifiers.Control) ? response.Text.ToUpper() : response.Text));
             }
         }
     }

--- a/src/PrettyPrompt/Console/KeyPressPattern.cs
+++ b/src/PrettyPrompt/Console/KeyPressPattern.cs
@@ -8,7 +8,7 @@ using System;
 
 namespace PrettyPrompt.Consoles;
 
-public readonly struct KeyPressPattern
+public readonly struct KeyPressPattern : IEquatable<KeyPressPattern>
 {
     public readonly ConsoleModifiers Modifiers;
     public readonly ConsoleKey Key;
@@ -25,13 +25,34 @@ public readonly struct KeyPressPattern
         Key = key;
     }
 
-    /// <summary>
-    /// See <see cref="KeyPress.Pattern"/>.
-    /// </summary>
-    public bool EqualsObjectPattern(object? pattern) => pattern switch
+    internal KeyPressPattern(object pattern)
     {
-        ConsoleKey key => Modifiers == default && Key == key,
-        (ConsoleModifiers modifiers, ConsoleKey key) => Modifiers == modifiers && Key == key,
-        _ => throw new InvalidOperationException("invalid format of key pattern"),
-    };
+        if (pattern is ConsoleKey key)
+        {
+            Modifiers = default;
+            Key = key;
+        }
+        else if (pattern is (ConsoleModifiers modifiers, ConsoleKey key2))
+        {
+            Modifiers = modifiers;
+            Key = key2;
+        }
+        else
+        {
+            throw new InvalidOperationException("invalid format of key pattern");
+        }
+    }
+
+    public static bool operator !=(KeyPressPattern left, KeyPressPattern right) => !(left == right);
+    public static bool operator ==(KeyPressPattern left, KeyPressPattern right) => left.Modifiers == right.Modifiers && left.Key == right.Key;
+
+    public static bool operator !=(KeyPressPattern left, ConsoleKey right) => !(left == right);
+    public static bool operator ==(KeyPressPattern left, ConsoleKey right) => left == new KeyPressPattern(right);
+
+    public static bool operator !=(KeyPressPattern left, (ConsoleModifiers Modifiers, ConsoleKey Key) right) => !(left == right);
+    public static bool operator ==(KeyPressPattern left, (ConsoleModifiers Modifiers, ConsoleKey Key) right) => left == new KeyPressPattern(right.Modifiers, right.Key);
+
+    public bool Equals(KeyPressPattern pattern) => this == pattern;
+    public override bool Equals(object? obj) => obj is KeyPressPattern other && this == other;
+    public override int GetHashCode() => (Modifiers, Key).GetHashCode();
 }

--- a/src/PrettyPrompt/Console/KeyPressPatterns.cs
+++ b/src/PrettyPrompt/Console/KeyPressPatterns.cs
@@ -1,0 +1,30 @@
+﻿#region License Header
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#endregion
+
+namespace PrettyPrompt.Consoles;
+
+public readonly struct KeyPressPatterns
+{
+    private readonly KeyPressPattern[] definedPatterns;
+
+    public KeyPressPatterns(params KeyPressPattern[] definedPatterns)
+        => this.definedPatterns = definedPatterns;
+
+    public static implicit operator KeyPressPatterns(KeyPressPattern[] definedPatterns)
+        => new(definedPatterns);
+
+    public bool Matches(KeyPressPattern pattern)
+    {
+        foreach (var definedPattern in definedPatterns)
+        {
+            if (definedPattern == pattern)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/PrettyPrompt/KeyBindings.cs
+++ b/src/PrettyPrompt/KeyBindings.cs
@@ -15,10 +15,14 @@ public class KeyBindings
 {
     public KeyPressPatterns CommitCompletion { get; }
     public KeyPressPatterns TriggerCompletionList { get; }
+    public KeyPressPatterns NewLine { get; }
+    public KeyPressPatterns SubmitPrompt { get; }
 
     public KeyBindings(
         KeyPressPattern[]? commitCompletion = null,
-        KeyPressPattern[]? triggerCompletionList = null)
+        KeyPressPattern[]? triggerCompletionList = null,
+        KeyPressPattern[]? newLine = null,
+        KeyPressPattern[]? submitPrompt = null)
     {
         CommitCompletion = commitCompletion ?? new KeyPressPattern[]
         {
@@ -30,31 +34,17 @@ public class KeyBindings
         {
             new(Control, Spacebar),
         };
-    }
 
-    public readonly struct KeyPressPatterns
-    {
-        private readonly KeyPressPattern[] definedPatterns;
-
-        public KeyPressPatterns(KeyPressPattern[] definedPatterns)
-            => this.definedPatterns = definedPatterns;
-
-        public static implicit operator KeyPressPatterns(KeyPressPattern[] definedPatterns)
-            => new(definedPatterns);
-
-        /// <summary>
-        /// See <see cref="KeyPress.Pattern"/>.
-        /// </summary>
-        public bool Matches(object pattern)
+        NewLine = newLine ?? new KeyPressPattern[]
         {
-            foreach (var definedPattern in definedPatterns)
-            {
-                if (definedPattern.EqualsObjectPattern(pattern))
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
+            new(Shift, Enter),
+        };
+
+        SubmitPrompt = submitPrompt ?? new KeyPressPattern[]
+        {
+            new(Enter),
+            new(Control, Enter),
+            new(Control | Alt, Enter),
+        };
     }
 }

--- a/src/PrettyPrompt/Panes/CompletionPane.cs
+++ b/src/PrettyPrompt/Panes/CompletionPane.cs
@@ -104,6 +104,7 @@ internal class CompletionPane : IKeyPressHandler
             return;
         }
 
+        var keyPattern = new KeyPressPattern(key.Pattern);
         switch (key.Pattern)
         {
             case DownArrow:
@@ -114,12 +115,12 @@ internal class CompletionPane : IKeyPressHandler
                 this.FilteredView.DecrementSelectedIndex();
                 key.Handled = true;
                 break;
-            case var pattern when configuration.KeyBindings.CommitCompletion.Matches(pattern):
+            case var _ when configuration.KeyBindings.CommitCompletion.Matches(keyPattern):
                 Debug.Assert(!FilteredView.IsEmpty);
                 await InsertCompletion(codePane.Document, FilteredView.SelectedItem).ConfigureAwait(false);
                 key.Handled = true;
                 break;
-            case var pattern when configuration.KeyBindings.TriggerCompletionList.Matches(pattern):
+            case var _ when configuration.KeyBindings.TriggerCompletionList.Matches(keyPattern):
                 key.Handled = true;
                 break;
             case Home or (_, Home):

--- a/src/PrettyPrompt/PromptCallbacks.cs
+++ b/src/PrettyPrompt/PromptCallbacks.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using PrettyPrompt.Completion;
+using PrettyPrompt.Consoles;
 using PrettyPrompt.Documents;
 using PrettyPrompt.Highlighting;
 
@@ -37,7 +38,7 @@ public delegate Task<KeyPressCallbackResult?> KeyPressCallbackAsync(string text,
 internal interface IPromptCallbacks
 {
     IReadOnlyDictionary<object, KeyPressCallbackAsync> KeyPressCallbacks { get; }
-    Task<bool> ForceSoftEnterAsync(string text);
+    Task<bool> InterpretKeyPressAsInputSubmit(string text, int caret, KeyPressPattern keyPress);
     Task<IReadOnlyList<CompletionItem>> GetCompletionItemsAsync(string text, int caret, TextSpan spanToBeReplaced);
     Task<TextSpan> GetSpanToReplaceByCompletionkAsync(string text, int caret);
     Task<IReadOnlyCollection<FormatSpan>> HighlightCallbackAsync(string text);
@@ -154,14 +155,16 @@ public class PromptCallbacks : IPromptCallbacks
         => Task.FromResult<IReadOnlyCollection<FormatSpan>>(Array.Empty<FormatSpan>());
 
     /// <summary>
-    /// Defines whether pressing "Enter" should insert a
-    /// newline ("soft-enter") or if the prompt should be submitted instead.
+    /// Defines whether given <see cref="KeyPressPattern"/> should be interpreted as
+    /// the prompt input submit.
     /// </summary>
-    /// <param name="text">The current input text on the prompt.</param>
+    /// <param name="text">The user's input text</param>
+    /// <param name="caret">The index of the text caret in the input text</param>
+    /// <param name="keyPress">Key press pattern in question</param>
     /// <returns>
-    /// true if a newline should be inserted ("soft-enter") or false if the prompt should be submitted.
+    /// <see langword="true"/> if the prompt should be submitted or <see langword="false"/> newline should be inserted ("soft-enter").
     /// </returns>
-    public virtual Task<bool> ForceSoftEnterAsync(string text)
+    public virtual Task<bool> InterpretKeyPressAsInputSubmit(string text, int caret, KeyPressPattern keyPress)
         => Task.FromResult(false);
 
     /// <summary>

--- a/tests/PrettyPrompt.Tests/PromptTests.cs
+++ b/tests/PrettyPrompt.Tests/PromptTests.cs
@@ -44,7 +44,8 @@ public class PromptTests
         var result = await prompt.ReadLineAsync();
 
         Assert.True(result.IsSuccess);
-        Assert.True(result.IsHardEnter);
+        Assert.Equal(Control, result.SubmitPattern.Modifiers);
+        Assert.Equal(Enter, result.SubmitPattern.Key);
         Assert.Equal("Hello World", result.Text);
     }
 
@@ -311,14 +312,14 @@ public class PromptTests
         var prompt = new Prompt(callbacks: new TestPromptCallbacks(
             new Dictionary<object, KeyPressCallbackAsync>()
             {
-                [F2] = (inputArg, caretArg) => {
+                [F2] = (inputArg, caretArg) =>
+                {
                     return Task.FromResult<KeyPressCallbackResult?>(callbackOutput);
                 }
-            }), 
+            }),
             console: console);
 
         var result = await prompt.ReadLineAsync();
-
         Assert.Equal(callbackOutput, result);
     }
 }

--- a/tests/PrettyPrompt.Tests/TestPromptCallbacks.cs
+++ b/tests/PrettyPrompt.Tests/TestPromptCallbacks.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using PrettyPrompt.Completion;
+using PrettyPrompt.Consoles;
 using PrettyPrompt.Documents;
 using PrettyPrompt.Highlighting;
 
@@ -10,7 +11,7 @@ internal delegate Task<TextSpan> SpanToReplaceByCompletionCallbackAsync(string t
 internal delegate Task<IReadOnlyList<CompletionItem>> CompletionCallbackAsync(string text, int caret, TextSpan spanToBeReplaced);
 internal delegate Task<bool> OpenCompletionWindowCallbackAsync(string text, int caret);
 internal delegate Task<IReadOnlyCollection<FormatSpan>> HighlightCallbackAsync(string text);
-internal delegate Task<bool> ForceSoftEnterCallbackAsync(string text);
+internal delegate Task<bool> ForceSoftEnterCallbackAsync(string text, int caret, KeyPressPattern keyPress);
 
 internal class TestPromptCallbacks : PromptCallbacks
 {
@@ -18,7 +19,7 @@ internal class TestPromptCallbacks : PromptCallbacks
     public CompletionCallbackAsync? CompletionCallback { get; set; }
     public OpenCompletionWindowCallbackAsync? OpenCompletionWindowCallback { get; set; }
     public HighlightCallbackAsync? HighlightCallback { get; set; }
-    public ForceSoftEnterCallbackAsync? ForceSoftEnterCallback { get; set; }
+    public ForceSoftEnterCallbackAsync? InterpretKeyPressAsInputSubmitCallback { get; set; }
 
     public TestPromptCallbacks(Dictionary<object, KeyPressCallbackAsync>? keyPressCallbacks = null)
     {
@@ -63,11 +64,11 @@ internal class TestPromptCallbacks : PromptCallbacks
             HighlightCallback(text);
     }
 
-    public override Task<bool> ForceSoftEnterAsync(string text)
+    public override Task<bool> InterpretKeyPressAsInputSubmit(string text, int caret, KeyPressPattern keyPress)
     {
         return
-            ForceSoftEnterCallback is null ?
-            base.ForceSoftEnterAsync(text) :
-            ForceSoftEnterCallback(text);
+            InterpretKeyPressAsInputSubmitCallback is null ?
+            base.InterpretKeyPressAsInputSubmit(text, caret, keyPress) :
+            InterpretKeyPressAsInputSubmitCallback(text, caret, keyPress);
     }
 }


### PR DESCRIPTION
Callback 
```C#
Task<bool> ForceSoftEnterAsync(string text)
```
was changed to
```C#
Task<bool> InterpretKeyPressAsInputSubmit(string text, int caret, KeyPressPattern keyPress);
```
and on ```PromptResult ```
```C#
bool IsHardEnter { get; }
```
was changed to
```C#
KeyPressPattern SubmitPattern { get; }
```
Both are more general and it's needed when key bindings are configurable for new lines and prompt submitting.