### PR TITLE
Enhancements of PromptCallbacks

### DIFF
--- a/examples/PrettyPrompt.Examples.FruitPrompt/Program.cs
+++ b/examples/PrettyPrompt.Examples.FruitPrompt/Program.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using PrettyPrompt.Completion;
+using PrettyPrompt.Consoles;
 using PrettyPrompt.Documents;
 using PrettyPrompt.Highlighting;
 
@@ -17,7 +18,7 @@ internal static class Program
         Console.WriteLine();
 
         var prompt = new Prompt(
-            persistentHistoryFilepath: "./history-file", 
+            persistentHistoryFilepath: "./history-file",
             callbacks: new FruitPromptCallbacks(),
             configuration: new PromptConfiguration(
                 prompt: new FormattedString(">>> ", new FormatSpan(0, 1, AnsiColor.Red), new FormatSpan(1, 1, AnsiColor.Yellow), new FormatSpan(2, 1, AnsiColor.Green)),
@@ -130,17 +131,15 @@ internal static class Program
 
     class FruitPromptCallbacks : PromptCallbacks
     {
-        public FruitPromptCallbacks()
+        protected override IEnumerable<(KeyPressPattern Pattern, KeyPressCallbackAsync Callback)> GetKeyPressCallbacks()
         {
             // registers functions to be called when the user presses a key. The text
             // currently typed into the prompt, along with the caret position within
             // that text are provided as callback parameters.
-            keyPressCallbacks.Add(
-                (ConsoleModifiers.Control, ConsoleKey.F1), // could also just provide a ConsoleKey, instead of a tuple
-                ShowFruitDocumentation);
+            yield return (new(ConsoleModifiers.Control, ConsoleKey.F1), ShowFruitDocumentation);
         }
 
-        public override Task<IReadOnlyList<CompletionItem>> GetCompletionItemsAsync(string text, int caret, TextSpan spanToBeReplaced)
+        protected override Task<IReadOnlyList<CompletionItem>> GetCompletionItemsAsync(string text, int caret, TextSpan spanToBeReplaced)
         {
             // demo completion algorithm callback
             // populate completions and documentation for autocompletion window
@@ -162,7 +161,7 @@ internal static class Program
             );
         }
 
-        public override Task<IReadOnlyCollection<FormatSpan>> HighlightCallbackAsync(string text)
+        protected override Task<IReadOnlyCollection<FormatSpan>> HighlightCallbackAsync(string text)
         {
             // demo syntax highlighting callback
             IReadOnlyCollection<FormatSpan> spans = EnumerateFormatSpans(text, Fruits.Select(f => (f.Name, f.Highlight))).ToList();

--- a/src/PrettyPrompt/Console/KeyPressPattern.cs
+++ b/src/PrettyPrompt/Console/KeyPressPattern.cs
@@ -39,7 +39,7 @@ public readonly struct KeyPressPattern : IEquatable<KeyPressPattern>
         }
         else
         {
-            throw new InvalidOperationException("invalid format of key pattern");
+            throw new InvalidOperationException("Invalid format of key pattern. It has to be ConsoleKey or ValueTuple<ConsoleModifiers, ConsoleKey>.");
         }
     }
 

--- a/src/PrettyPrompt/Documents/TextSpan.cs
+++ b/src/PrettyPrompt/Documents/TextSpan.cs
@@ -58,7 +58,7 @@ public readonly struct TextSpan : IEquatable<TextSpan>
     /// <summary>
     /// Determines whether the position lies within the span.
     /// </summary>
-    public bool Contains(int index) => index >= Start && index < Start + Length;
+    public bool Contains(int index) => index >= Start && index < End;
 
     /// <summary>
     /// Determines whether span falls completely within this span.

--- a/src/PrettyPrompt/Prompt.cs
+++ b/src/PrettyPrompt/Prompt.cs
@@ -119,7 +119,7 @@ public sealed class Prompt : IPrompt
     private async Task<PromptResult?> GetResult(CodePane codePane, KeyPress key, string inputText)
     {
         // process any user-defined keyboard shortcuts
-        if (promptCallbacks.KeyPressCallbacks.TryGetValue(key.Pattern, out var callback))
+        if (promptCallbacks.KeyPressCallbacks.TryGetValue(new KeyPressPattern(key.Pattern), out var callback))
         {
             var result = await callback.Invoke(inputText, codePane.Document.Caret).ConfigureAwait(false);
             if (result is not null)
@@ -206,7 +206,7 @@ public class PromptResult
 }
 
 /// <summary>
-/// Represents the result of a user's key press, when they pressed a keybinding from <see cref="PromptCallbacks.KeyPressCallbacks"/>.
+/// Represents the result of a user's key press, when they pressed a keybinding from <see cref="PromptCallbacks.GetKeyPressCallbacks"/>.
 /// </summary>
 public class KeyPressCallbackResult : PromptResult
 {

--- a/tests/PrettyPrompt.Tests/PromptTests.cs
+++ b/tests/PrettyPrompt.Tests/PromptTests.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NSubstitute;
+using PrettyPrompt.Consoles;
 using PrettyPrompt.Documents;
 using PrettyPrompt.Highlighting;
 using Xunit;
@@ -253,11 +254,11 @@ public class PromptTests
         string? input = null;
         int? caret = null;
         var prompt = new Prompt(callbacks: new TestPromptCallbacks(
-            new Dictionary<object, KeyPressCallbackAsync>()
-            {
-                [F1] = (inputArg, caretArg) => { input = inputArg; caret = caretArg; return Task.FromResult<KeyPressCallbackResult?>(null); }
-            }
-        ), console: console);
+            (
+                new KeyPressPattern(F1),
+                (inputArg, caretArg) => { input = inputArg; caret = caretArg; return Task.FromResult<KeyPressCallbackResult?>(null); }
+        )),
+            console: console);
 
         _ = await prompt.ReadLineAsync();
 
@@ -310,13 +311,13 @@ public class PromptTests
 
         var callbackOutput = new KeyPressCallbackResult("", "Callback output!");
         var prompt = new Prompt(callbacks: new TestPromptCallbacks(
-            new Dictionary<object, KeyPressCallbackAsync>()
-            {
-                [F2] = (inputArg, caretArg) =>
+            (
+                new KeyPressPattern(F2),
+                (inputArg, caretArg) =>
                 {
                     return Task.FromResult<KeyPressCallbackResult?>(callbackOutput);
                 }
-            }),
+        )),
             console: console);
 
         var result = await prompt.ReadLineAsync();


### PR DESCRIPTION
All virtual methods in PromptCallbacks are now protected and have public non-virtual wraps with possible default implementation or validations.
KeyPressCallbacks uses KeyPressPattern instead of object.
IPromptCallbacks is public.