### PR TITLE
Customizable completion item priority + reworked SlidingArrayWindow.

### DIFF
--- a/examples/PrettyPrompt.Examples.FruitPrompt/Program.cs
+++ b/examples/PrettyPrompt.Examples.FruitPrompt/Program.cs
@@ -146,7 +146,6 @@ internal static class Program
             var typedWord = text.AsSpan(spanToBeReplaced.Start, spanToBeReplaced.Length).ToString();
             return Task.FromResult<IReadOnlyList<CompletionItem>>(
                 Fruits
-                .Where(fruit => fruit.Name.StartsWith(typedWord, StringComparison.InvariantCultureIgnoreCase))
                 .Select(fruit =>
                 {
                     var displayText = new FormattedString(fruit.Name, new FormatSpan(0, fruit.Name.Length, fruit.Highlight));

--- a/src/PrettyPrompt/Extensions.cs
+++ b/src/PrettyPrompt/Extensions.cs
@@ -7,14 +7,15 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Security;
 using System.Text;
 using PrettyPrompt.Documents;
 
 namespace PrettyPrompt;
 
-internal static class Extensions
+public static class Extensions
 {
-    public static string EnvironmentNewlines(this string text) =>
+    internal static string EnvironmentNewlines(this string text) =>
         Environment.NewLine == "\n"
             ? text
             : text.Replace("\n", Environment.NewLine);
@@ -23,7 +24,7 @@ internal static class Extensions
     /// Like <see cref="System.Linq.Enumerable.Zip{TFirst, TSecond}(IEnumerable{TFirst}, IEnumerable{TSecond})"/>,
     /// but the length of the zipped sequence is equal to the longer enumerable (with default(T) elements for the shorter enumerable).
     /// </summary>
-    public static IEnumerable<(int, T1?, T2?)> ZipLongest<T1, T2>(this IEnumerable<T1> left, IEnumerable<T2> right)
+    internal static IEnumerable<(int, T1?, T2?)> ZipLongest<T1, T2>(this IEnumerable<T1> left, IEnumerable<T2> right)
     {
         var leftEnumerator = left.GetEnumerator();
         var rightEnumerator = right.GetEnumerator();
@@ -53,7 +54,7 @@ internal static class Extensions
         }
     }
 
-    public static bool TryGet<T>(this T? nullableValue, out T value)
+    internal static bool TryGet<T>(this T? nullableValue, out T value)
         where T : struct
     {
         if (nullableValue.HasValue)
@@ -68,35 +69,35 @@ internal static class Extensions
         }
     }
 
-    public static ConsoleKeyInfo ToKeyInfo(this ConsoleKey consoleKey, char character, ConsoleModifiers modifiersPressed)
+    internal static ConsoleKeyInfo ToKeyInfo(this ConsoleKey consoleKey, char character, ConsoleModifiers modifiersPressed)
        => consoleKey.ToKeyInfo(
            character,
            shift: modifiersPressed.HasFlag(ConsoleModifiers.Shift),
            alt: modifiersPressed.HasFlag(ConsoleModifiers.Alt),
            control: modifiersPressed.HasFlag(ConsoleModifiers.Control));
 
-    public static ConsoleKeyInfo ToKeyInfo(this ConsoleKey consoleKey, char character, bool shift = false, bool alt = false, bool control = false)
+    internal static ConsoleKeyInfo ToKeyInfo(this ConsoleKey consoleKey, char character, bool shift = false, bool alt = false, bool control = false)
        => new(character, consoleKey, shift, alt, control);
 
-    public static int Clamp(this int value, int min, int max)
+    internal static int Clamp(this int value, int min, int max)
     {
         Debug.Assert(min <= max);
         return value < min ? min : (value > max ? max : value);
     }
 
-    public static void SetContents(this StringBuilder sb, ReadOnlyStringBuilder contents)
+    internal static void SetContents(this StringBuilder sb, ReadOnlyStringBuilder contents)
     {
         sb.Clear();
         contents.AppendTo(sb);
     }
 
-    public static void SetContents(this StringBuilder sb, string contents)
+    internal static void SetContents(this StringBuilder sb, string contents)
     {
         sb.Clear();
         sb.Append(contents);
     }
 
-    public static bool StartsWith(this string text, ReadOnlyStringBuilder prefix)
+    internal static bool StartsWith(this string text, ReadOnlyStringBuilder prefix)
     {
         if (prefix.Length > text.Length) return false;
         for (int i = 0; i < prefix.Length; i++)
@@ -105,4 +106,7 @@ internal static class Extensions
         }
         return true;
     }
+
+    public static ReadOnlySpan<char> AsSpan(this string text, TextSpan span)
+        => text.AsSpan(span.Start, span.Length);
 }

--- a/src/PrettyPrompt/Panes/CodePane.cs
+++ b/src/PrettyPrompt/Panes/CodePane.cs
@@ -115,7 +115,7 @@ internal class CodePane : IKeyPressHandler
         await selectionHandler.OnKeyDown(key).ConfigureAwait(false);
         var selection = GetSelectionSpan();
 
-        if (await promptCallbacks.InterpretKeyPressAsInputSubmit(Document.GetText(), Document.Caret, key.ConsoleKeyInfo).ConfigureAwait(false))
+        if (await promptCallbacks.InterpretKeyPressAsInputSubmitAsync(Document.GetText(), Document.Caret, key.ConsoleKeyInfo).ConfigureAwait(false))
         {
             Result = new PromptResult(isSuccess: true, Document.GetText().EnvironmentNewlines(), key.ConsoleKeyInfo);
             return;

--- a/src/PrettyPrompt/PromptCallbacks.cs
+++ b/src/PrettyPrompt/PromptCallbacks.cs
@@ -81,9 +81,7 @@ public interface IPromptCallbacks
     /// </summary>
     /// <param name="text">The user's input text</param>
     /// <param name="caret">The index of the text caret in the input text</param>
-    /// <returns>
-    /// A value indicating whether the completion window should automatically open.
-    /// </returns>
+    /// <returns>A value indicating whether the completion window should automatically open.</returns>
     Task<bool> ShouldOpenCompletionWindowAsync(string text, int caret);
 
     /// <summary>
@@ -93,17 +91,15 @@ public interface IPromptCallbacks
     /// <param name="text">The user's input text</param>
     /// <param name="caret">The index of the text caret in the input text</param>
     /// <param name="keyInfo">Key press pattern in question</param>
-    /// <returns>
-    /// <see langword="true"/> if the prompt should be submitted or <see langword="false"/> newline should be inserted ("soft-enter").
-    /// </returns>
-    Task<bool> InterpretKeyPressAsInputSubmit(string text, int caret, ConsoleKeyInfo keyInfo);
+    /// <returns><see langword="true"/> if the prompt should be submitted or <see langword="false"/> newline should be inserted ("soft-enter").</returns>
+    Task<bool> InterpretKeyPressAsInputSubmitAsync(string text, int caret, ConsoleKeyInfo keyInfo);
 }
 
 public class PromptCallbacks : IPromptCallbacks
 {
     private (KeyPressPattern Pattern, KeyPressCallbackAsync Callback)[]? keyPressCallbacks;
 
-    bool IPromptCallbacks.TryGetKeyPressCallbacks(ConsoleKeyInfo keyInfo, [NotNullWhen(true)]out KeyPressCallbackAsync? result)
+    bool IPromptCallbacks.TryGetKeyPressCallbacks(ConsoleKeyInfo keyInfo, [NotNullWhen(true)] out KeyPressCallbackAsync? result)
     {
         keyPressCallbacks ??= GetKeyPressCallbacks().ToArray();
         foreach (var (pattern, callback) in keyPressCallbacks)
@@ -151,11 +147,11 @@ public class PromptCallbacks : IPromptCallbacks
         return ShouldOpenCompletionWindowAsync(text, caret);
     }
 
-    Task<bool> IPromptCallbacks.InterpretKeyPressAsInputSubmit(string text, int caret, ConsoleKeyInfo keyInfo)
+    Task<bool> IPromptCallbacks.InterpretKeyPressAsInputSubmitAsync(string text, int caret, ConsoleKeyInfo keyInfo)
     {
         Debug.Assert(caret >= 0 && caret <= text.Length);
 
-        return InterpretKeyPressAsInputSubmit(text, caret, keyInfo);
+        return InterpretKeyPressAsInputSubmitAsync(text, caret, keyInfo);
     }
 
 
@@ -231,7 +227,7 @@ public class PromptCallbacks : IPromptCallbacks
         return Task.FromResult(caret - 2 >= 0 && char.IsWhiteSpace(text[caret - 2]) && char.IsLetter(text[caret - 1]));
     }
 
-    /// <inheritdoc cref="IPromptCallbacks.InterpretKeyPressAsInputSubmit"/>
-    protected virtual Task<bool> InterpretKeyPressAsInputSubmit(string text, int caret, ConsoleKeyInfo keyInfo)
+    /// <inheritdoc cref="IPromptCallbacks.InterpretKeyPressAsInputSubmitAsync"/>
+    protected virtual Task<bool> InterpretKeyPressAsInputSubmitAsync(string text, int caret, ConsoleKeyInfo keyInfo)
         => Task.FromResult(false);
 }

--- a/tests/PrettyPrompt.Tests/CompletionTests.cs
+++ b/tests/PrettyPrompt.Tests/CompletionTests.cs
@@ -36,15 +36,15 @@ public class CompletionTests
     public async Task ReadLine_MultipleCompletion()
     {
         var console = ConsoleStub.NewConsole();
-        // complete 3 animals. For the third animal, start completing Alligator, but then backspace, navigate the completion menu and complete as Alpaca instead.
-        console.StubInput($"Aa{Enter} Z{Tab} Alli{Backspace}{Backspace}{DownArrow}{UpArrow}{DownArrow}{DownArrow}{Enter}{Enter}");
+        // complete 3 animals. For the third animal, start completing Alligator, but then backspace, navigate the completion menu and complete as Albatross instead.
+        console.StubInput($"Aa{Enter} Z{Tab} Alli{Backspace}{Backspace}{DownArrow}{UpArrow}{DownArrow}{Enter}{Enter}");
 
         var prompt = ConfigurePrompt(console);
 
         var result = await prompt.ReadLineAsync();
 
         Assert.True(result.IsSuccess);
-        Assert.Equal("Aardvark Zebra Alpaca", result.Text);
+        Assert.Equal("Aardvark Zebra Albatross", result.Text);
     }
 
     [Fact]
@@ -72,7 +72,7 @@ public class CompletionTests
         var result = await prompt.ReadLineAsync();
 
         Assert.True(result.IsSuccess);
-        Assert.Equal($"Aardvark{NewLine}Zebra", result.Text);
+        Assert.Equal($"Ant{NewLine}Zebra", result.Text);
     }
 
     [Fact]
@@ -163,7 +163,7 @@ public class CompletionTests
         var result = await prompt.ReadLineAsync();
 
         Assert.True(result.IsSuccess);
-        Assert.Equal($"Aardvark a", result.Text);
+        Assert.Equal($"Ant a", result.Text);
     }
 
     [Fact]
@@ -177,7 +177,7 @@ public class CompletionTests
         var result = await prompt.ReadLineAsync();
 
         Assert.True(result.IsSuccess);
-        Assert.Equal($"Aardvark Q", result.Text);
+        Assert.Equal($"Ant Q", result.Text);
     }
 
     /// <summary>

--- a/tests/PrettyPrompt.Tests/TestPromptCallbacks.cs
+++ b/tests/PrettyPrompt.Tests/TestPromptCallbacks.cs
@@ -63,11 +63,11 @@ internal class TestPromptCallbacks : PromptCallbacks
             HighlightCallback(text);
     }
 
-    protected override Task<bool> InterpretKeyPressAsInputSubmit(string text, int caret, ConsoleKeyInfo keyInfo)
+    protected override Task<bool> InterpretKeyPressAsInputSubmitAsync(string text, int caret, ConsoleKeyInfo keyInfo)
     {
         return
             InterpretKeyPressAsInputSubmitCallback is null ?
-            base.InterpretKeyPressAsInputSubmit(text, caret, keyInfo) :
+            base.InterpretKeyPressAsInputSubmitAsync(text, caret, keyInfo) :
             InterpretKeyPressAsInputSubmitCallback(text, caret, keyInfo);
     }
 }


### PR DESCRIPTION
Resolves #108 and #109.

```CompletionItem``` now have overridable method ```GetCompletionItemPriority```. The default implementation is now smarter than the original matching with ```StartWith```.
![PrettyPrompt Examples FruitPrompt_VKRKjaubZq](https://user-images.githubusercontent.com/11704036/153727269-1a47b312-e85e-454e-8338-4d77f293c3e1.gif)

