### PR TITLE
Cancellation tokens propagation.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,12 @@ dotnet_diagnostic.CS1591.severity = none
 dotnet_diagnostic.S3358.severity = none
 
 csharp_style_namespace_declarations=file_scoped:warning
+
+# CA1068: CancellationToken parameters must come last
+dotnet_diagnostic.CA1068.severity = warning
+
+# CA2250: Use ThrowIfCancellationRequested
+dotnet_diagnostic.CA2250.severity = warning
+
+# CA2016: Forward the CancellationToken parameter to methods that take one
+dotnet_diagnostic.CA2016.severity = warning

--- a/examples/PrettyPrompt.Examples.FruitPrompt/Program.cs
+++ b/examples/PrettyPrompt.Examples.FruitPrompt/Program.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using PrettyPrompt.Completion;
 using PrettyPrompt.Consoles;
@@ -83,7 +84,7 @@ internal static class Program
         }
     }
 
-    private static Task<KeyPressCallbackResult?> ShowFruitDocumentation(string text, int caret)
+    private static Task<KeyPressCallbackResult?> ShowFruitDocumentation(string text, int caret, CancellationToken cancellationToken)
     {
         string wordUnderCursor = GetWordAtCaret(text, caret).ToLower();
 
@@ -139,7 +140,7 @@ internal static class Program
             yield return (new(ConsoleModifiers.Control, ConsoleKey.F1), ShowFruitDocumentation);
         }
 
-        protected override Task<IReadOnlyList<CompletionItem>> GetCompletionItemsAsync(string text, int caret, TextSpan spanToBeReplaced)
+        protected override Task<IReadOnlyList<CompletionItem>> GetCompletionItemsAsync(string text, int caret, TextSpan spanToBeReplaced, CancellationToken cancellationToken)
         {
             // demo completion algorithm callback
             // populate completions and documentation for autocompletion window
@@ -153,14 +154,14 @@ internal static class Program
                     return new CompletionItem(
                         replacementText: fruit.Name,
                         displayText: displayText,
-                        extendedDescription: new Lazy<Task<FormattedString>>(() => Task.FromResult(description))
+                        getExtendedDescription: _ => Task.FromResult(description)
                     );
                 })
                 .ToArray()
             );
         }
 
-        protected override Task<IReadOnlyCollection<FormatSpan>> HighlightCallbackAsync(string text)
+        protected override Task<IReadOnlyCollection<FormatSpan>> HighlightCallbackAsync(string text, CancellationToken cancellationToken)
         {
             // demo syntax highlighting callback
             IReadOnlyCollection<FormatSpan> spans = EnumerateFormatSpans(text, Fruits.Select(f => (f.Name, f.Highlight))).ToList();

--- a/src/PrettyPrompt/Completion/CompletionItem.cs
+++ b/src/PrettyPrompt/Completion/CompletionItem.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 using PrettyPrompt.Documents;
 using PrettyPrompt.Highlighting;
@@ -18,6 +19,8 @@ namespace PrettyPrompt.Completion;
 [DebuggerDisplay("{DisplayText}")]
 public class CompletionItem
 {
+    public delegate Task<FormattedString> GetExtendedDescriptionHandler(CancellationToken cancellationToken);
+
     /// <summary>
     /// When the completion item is selected, this text will be inserted into the document at the specified start index.
     /// </summary>
@@ -41,25 +44,26 @@ public class CompletionItem
     /// <summary>
     /// This task will be executed when the item is selected, to display the extended "tool tip" description to the right of the menu.
     /// </summary>
-    public Task<FormattedString> GetExtendedDescriptionAsync()
-        => extendedDescription?.Value ?? Task.FromResult(FormattedString.Empty);
+    public Task<FormattedString> GetExtendedDescriptionAsync(CancellationToken cancellationToken) => getExtendedDescription(cancellationToken);
 
-    private readonly Lazy<Task<FormattedString>>? extendedDescription;
+    private readonly GetExtendedDescriptionHandler getExtendedDescription;
 
     /// <param name="replacementText">When the completion item is selected, this text will be inserted into the document at the specified start index.</param>
     /// <param name="displayText">This text will be displayed in the completion menu. If not specified, the <paramref name="replacementText"/> value will be used.</param>
-    /// <param name="extendedDescription">This lazy task will be executed when the item is selected, to display the extended "tool tip" description to the right of the menu.</param>
+    /// <param name="getExtendedDescription">This lazy task will be executed when the item is selected, to display the extended "tool tip" description to the right of the menu.</param>
     /// <param name="filterText">The text used to determine if the item matches the filter in the list. If not specified the <paramref name="replacementText"/> value is used.</param>
     public CompletionItem(
         string replacementText,
         FormattedString displayText = default,
         string? filterText = null,
-        Lazy<Task<FormattedString>>? extendedDescription = null)
+        GetExtendedDescriptionHandler? getExtendedDescription = null)
     {
         ReplacementText = replacementText;
         DisplayTextFormatted = displayText.IsEmpty ? replacementText : displayText;
         FilterText = filterText ?? replacementText;
-        this.extendedDescription = extendedDescription;
+
+        Task<FormattedString>? extendedDescriptionTask = null; //will be stored in closure of getExtendedDescription
+        this.getExtendedDescription = ct => extendedDescriptionTask ??= getExtendedDescription?.Invoke(ct) ?? Task.FromResult(FormattedString.Empty);
     }
 
     /// <summary>

--- a/src/PrettyPrompt/Console/IKeyPressHandler.cs
+++ b/src/PrettyPrompt/Console/IKeyPressHandler.cs
@@ -4,12 +4,13 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #endregion
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace PrettyPrompt.Consoles;
 
 internal interface IKeyPressHandler
 {
-    Task OnKeyDown(KeyPress key);
-    Task OnKeyUp(KeyPress key);
+    Task OnKeyDown(KeyPress key, CancellationToken cancellationToken);
+    Task OnKeyUp(KeyPress key, CancellationToken cancellationToken);
 }

--- a/src/PrettyPrompt/Highlighting/SyntaxHighlighter.cs
+++ b/src/PrettyPrompt/Highlighting/SyntaxHighlighter.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace PrettyPrompt.Highlighting;
@@ -28,7 +29,7 @@ class SyntaxHighlighter
         this.previousOutput = Array.Empty<FormatSpan>();
     }
 
-    public async Task<IReadOnlyCollection<FormatSpan>> HighlightAsync(string input)
+    public async Task<IReadOnlyCollection<FormatSpan>> HighlightAsync(string input, CancellationToken cancellationToken)
     {
         if (hasUserOptedOutFromColor) return Array.Empty<FormatSpan>();
 
@@ -37,7 +38,7 @@ class SyntaxHighlighter
             return previousOutput;
         }
 
-        var highlights = await promptCallbacks.HighlightCallbackAsync(input).ConfigureAwait(false);
+        var highlights = await promptCallbacks.HighlightCallbackAsync(input, cancellationToken).ConfigureAwait(false);
         previousInput = input;
         previousOutput = highlights;
         return highlights;

--- a/src/PrettyPrompt/History/HistoryLog.cs
+++ b/src/PrettyPrompt/History/HistoryLog.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using PrettyPrompt.Consoles;
 using PrettyPrompt.Documents;
@@ -79,9 +80,9 @@ sealed class HistoryLog : IKeyPressHandler
         }
     }
 
-    public Task OnKeyDown(KeyPress key) => Task.CompletedTask;
+    public Task OnKeyDown(KeyPress key, CancellationToken cancellationToken) => Task.CompletedTask;
 
-    public async Task OnKeyUp(KeyPress key)
+    public async Task OnKeyUp(KeyPress key, CancellationToken cancellationToken)
     {
         if (codePane is null) return;
 

--- a/src/PrettyPrompt/TextSelection/SelectionKeyPressHandler.cs
+++ b/src/PrettyPrompt/TextSelection/SelectionKeyPressHandler.cs
@@ -5,6 +5,7 @@
 #endregion
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using PrettyPrompt.Consoles;
 using PrettyPrompt.Panes;
@@ -23,7 +24,7 @@ class SelectionKeyPressHandler : IKeyPressHandler
         this.codePane = codePane;
     }
 
-    public Task OnKeyDown(KeyPress key)
+    public Task OnKeyDown(KeyPress key, CancellationToken cancellationToken)
     {
         this.previousCursorLocation = codePane.Cursor;
 
@@ -34,7 +35,7 @@ class SelectionKeyPressHandler : IKeyPressHandler
         return Task.CompletedTask;
     }
 
-    public Task OnKeyUp(KeyPress key)
+    public Task OnKeyUp(KeyPress key, CancellationToken cancellationToken)
     {
 
         switch (key.ObjectPattern)

--- a/tests/PrettyPrompt.Tests/CompletionTestData.cs
+++ b/tests/PrettyPrompt.Tests/CompletionTestData.cs
@@ -35,7 +35,7 @@ public class CompletionTestData
                 .Select((c, i) => new CompletionItem(
                     replacementText: c,
                     displayText: i % 2 == 0 ? c : null, // display text is optional, ReplacementText should be used when this is null.
-                    extendedDescription: new Lazy<Task<FormattedString>>(() => Task.FromResult<FormattedString>("a vivid description of " + c))
+                    getExtendedDescription: _ => Task.FromResult<FormattedString>("a vivid description of " + c)
                 ))
                 .ToArray()
         );

--- a/tests/PrettyPrompt.Tests/PromptTests.cs
+++ b/tests/PrettyPrompt.Tests/PromptTests.cs
@@ -258,7 +258,7 @@ public class PromptTests
         var prompt = new Prompt(callbacks: new TestPromptCallbacks(
             (
                 new KeyPressPattern(F1),
-                (inputArg, caretArg) => { input = inputArg; caret = caretArg; return Task.FromResult<KeyPressCallbackResult?>(null); }
+                (inputArg, caretArg, _) => { input = inputArg; caret = caretArg; return Task.FromResult<KeyPressCallbackResult?>(null); }
         )),
             console: console);
 
@@ -315,7 +315,7 @@ public class PromptTests
         var prompt = new Prompt(callbacks: new TestPromptCallbacks(
             (
                 new KeyPressPattern(F2),
-                (inputArg, caretArg) =>
+                (inputArg, caretArg, _) =>
                 {
                     return Task.FromResult<KeyPressCallbackResult?>(callbackOutput);
                 }

--- a/tests/PrettyPrompt.Tests/TestPromptCallbacks.cs
+++ b/tests/PrettyPrompt.Tests/TestPromptCallbacks.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using PrettyPrompt.Completion;
 using PrettyPrompt.Consoles;
@@ -31,43 +32,43 @@ internal class TestPromptCallbacks : PromptCallbacks
 
     protected override IEnumerable<(KeyPressPattern Pattern, KeyPressCallbackAsync Callback)> GetKeyPressCallbacks() => keyPressCallbacks;
 
-    protected override Task<TextSpan> GetSpanToReplaceByCompletionkAsync(string text, int caret)
+    protected override Task<TextSpan> GetSpanToReplaceByCompletionkAsync(string text, int caret, CancellationToken cancellationToken)
     {
         return
             SpanToReplaceByCompletionCallback is null ?
-            base.GetSpanToReplaceByCompletionkAsync(text, caret) :
+            base.GetSpanToReplaceByCompletionkAsync(text, caret, cancellationToken) :
             SpanToReplaceByCompletionCallback(text, caret);
     }
 
-    protected override Task<IReadOnlyList<CompletionItem>> GetCompletionItemsAsync(string text, int caret, TextSpan spanToBeReplaced)
+    protected override Task<IReadOnlyList<CompletionItem>> GetCompletionItemsAsync(string text, int caret, TextSpan spanToBeReplaced, CancellationToken cancellationToken)
     {
         return
             CompletionCallback is null ?
-            base.GetCompletionItemsAsync(text, caret, spanToBeReplaced) :
+            base.GetCompletionItemsAsync(text, caret, spanToBeReplaced, cancellationToken) :
             CompletionCallback(text, caret, spanToBeReplaced);
     }
 
-    protected override Task<bool> ShouldOpenCompletionWindowAsync(string text, int caret)
+    protected override Task<bool> ShouldOpenCompletionWindowAsync(string text, int caret, CancellationToken cancellationToken)
     {
         return
             OpenCompletionWindowCallback is null ?
-            base.ShouldOpenCompletionWindowAsync(text, caret) :
+            base.ShouldOpenCompletionWindowAsync(text, caret, cancellationToken) :
             OpenCompletionWindowCallback(text, caret);
     }
 
-    protected override Task<IReadOnlyCollection<FormatSpan>> HighlightCallbackAsync(string text)
+    protected override Task<IReadOnlyCollection<FormatSpan>> HighlightCallbackAsync(string text, CancellationToken cancellationToken)
     {
         return
             HighlightCallback is null ?
-            base.HighlightCallbackAsync(text) :
+            base.HighlightCallbackAsync(text, cancellationToken) :
             HighlightCallback(text);
     }
 
-    protected override Task<bool> InterpretKeyPressAsInputSubmitAsync(string text, int caret, ConsoleKeyInfo keyInfo)
+    protected override Task<bool> InterpretKeyPressAsInputSubmitAsync(string text, int caret, ConsoleKeyInfo keyInfo, CancellationToken cancellationToken)
     {
         return
             InterpretKeyPressAsInputSubmitCallback is null ?
-            base.InterpretKeyPressAsInputSubmitAsync(text, caret, keyInfo) :
+            base.InterpretKeyPressAsInputSubmitAsync(text, caret, keyInfo, cancellationToken) :
             InterpretKeyPressAsInputSubmitCallback(text, caret, keyInfo);
     }
 }


### PR DESCRIPTION
Public and internal API is extended by cancellation tokens. Cancellation itself is not supported yet.
This is a breaking change, so I'm adding it now before the 3.0 release.

Also ```CompletionItem.ExtendedDescription``` API was enhanced. Now it takes (async) delegate instead of ```Lazy<Task<...>>```.