### PR TITLE
InterpretKeyPressAsInputSubmitAsync -> TransformKeyPressAsync + 3.0.1

### DIFF
--- a/src/PrettyPrompt/Console/KeyPress.cs
+++ b/src/PrettyPrompt/Console/KeyPress.cs
@@ -12,7 +12,7 @@ using System.Linq;
 namespace PrettyPrompt.Consoles;
 
 [DebuggerDisplay("{ObjectPattern}")]
-internal class KeyPress
+public class KeyPress
 {
     /// <summary>
     /// The key press as reported by Console.ReadKey
@@ -31,7 +31,7 @@ internal class KeyPress
     /// </summary>
     public string? PastedText { get; }
 
-    public bool Handled { get; internal set; }
+    internal bool Handled { get; set; }
 
     public KeyPress(ConsoleKeyInfo consoleKeyInfo, string? pastedText = null)
     {
@@ -45,7 +45,7 @@ internal class KeyPress
         this.PastedText = pastedText;
     }
 
-    public static IEnumerable<KeyPress> ReadForever(IConsole console)
+    internal static IEnumerable<KeyPress> ReadForever(IConsole console)
     {
         while (true)
         {

--- a/src/PrettyPrompt/Extensions.cs
+++ b/src/PrettyPrompt/Extensions.cs
@@ -68,14 +68,14 @@ public static class Extensions
         }
     }
 
-    internal static ConsoleKeyInfo ToKeyInfo(this ConsoleKey consoleKey, char character, ConsoleModifiers modifiersPressed)
+    public static ConsoleKeyInfo ToKeyInfo(this ConsoleKey consoleKey, char character, ConsoleModifiers modifiersPressed)
        => consoleKey.ToKeyInfo(
            character,
            shift: modifiersPressed.HasFlag(ConsoleModifiers.Shift),
            alt: modifiersPressed.HasFlag(ConsoleModifiers.Alt),
            control: modifiersPressed.HasFlag(ConsoleModifiers.Control));
 
-    internal static ConsoleKeyInfo ToKeyInfo(this ConsoleKey consoleKey, char character, bool shift = false, bool alt = false, bool control = false)
+    public static ConsoleKeyInfo ToKeyInfo(this ConsoleKey consoleKey, char character, bool shift = false, bool alt = false, bool control = false)
        => new(character, consoleKey, shift, alt, control);
 
     internal static int Clamp(this int value, int min, int max)

--- a/src/PrettyPrompt/Panes/CodePane.cs
+++ b/src/PrettyPrompt/Panes/CodePane.cs
@@ -116,12 +116,6 @@ internal class CodePane : IKeyPressHandler
         await selectionHandler.OnKeyDown(key, cancellationToken).ConfigureAwait(false);
         var selection = GetSelectionSpan();
 
-        if (await promptCallbacks.InterpretKeyPressAsInputSubmitAsync(Document.GetText(), Document.Caret, key.ConsoleKeyInfo, cancellationToken).ConfigureAwait(false))
-        {
-            Result = new PromptResult(isSuccess: true, Document.GetText().EnvironmentNewlines(), key.ConsoleKeyInfo);
-            return;
-        }
-
         switch (key.ObjectPattern)
         {
             case (Control, C) when selection is null:
@@ -188,7 +182,7 @@ internal class CodePane : IKeyPressHandler
                 break;
             case (Control, X) when selection.TryGet(out var selectionValue):
                 {
-                    var cutContent =  Document.GetText(selectionValue).ToString();
+                    var cutContent = Document.GetText(selectionValue).ToString();
                     Document.Remove(this, selectionValue);
                     await clipboard.SetTextAsync(cutContent, cancellationToken).ConfigureAwait(false);
                     break;

--- a/src/PrettyPrompt/PrettyPrompt.csproj
+++ b/src/PrettyPrompt/PrettyPrompt.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>3.0.0</Version>
+    <Version>3.0.1</Version>
 
     <PackageId>PrettyPrompt</PackageId>
     <PackageTags>repl readline console cli</PackageTags>

--- a/src/PrettyPrompt/Prompt.cs
+++ b/src/PrettyPrompt/Prompt.cs
@@ -109,6 +109,8 @@ public sealed class Prompt : IPrompt
 
     private async Task InterpretKeyPress(KeyPress key, CodePane codePane, CompletionPane completionPane, CancellationToken cancellationToken)
     {
+        key = await promptCallbacks.TransformKeyPressAsync(codePane.Document.GetText(), codePane.Document.Caret, key, cancellationToken).ConfigureAwait(false);
+
         foreach (var panes in new IKeyPressHandler[] { completionPane, codePane, history })
             await panes.OnKeyDown(key, cancellationToken).ConfigureAwait(false);
 

--- a/src/PrettyPrompt/PromptCallbacks.cs
+++ b/src/PrettyPrompt/PromptCallbacks.cs
@@ -91,15 +91,14 @@ public interface IPromptCallbacks
     Task<bool> ShouldOpenCompletionWindowAsync(string text, int caret, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Defines whether given <see cref="KeyPressPattern"/> should be interpreted as
-    /// the prompt input submit.
+    /// Optionaly transforms key presses to another ones.
     /// </summary>
     /// <param name="text">The user's input text</param>
     /// <param name="caret">The index of the text caret in the input text</param>
-    /// <param name="keyInfo">Key press pattern in question</param>
+    /// <param name="keyPress">Key press pattern in question</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns><see langword="true"/> if the prompt should be submitted or <see langword="false"/> newline should be inserted ("soft-enter").</returns>
-    Task<bool> InterpretKeyPressAsInputSubmitAsync(string text, int caret, ConsoleKeyInfo keyInfo, CancellationToken cancellationToken);
+    Task<KeyPress> TransformKeyPressAsync(string text, int caret, KeyPress keyPress, CancellationToken cancellationToken);
 }
 
 public class PromptCallbacks : IPromptCallbacks
@@ -154,11 +153,11 @@ public class PromptCallbacks : IPromptCallbacks
         return ShouldOpenCompletionWindowAsync(text, caret, cancellationToken);
     }
 
-    Task<bool> IPromptCallbacks.InterpretKeyPressAsInputSubmitAsync(string text, int caret, ConsoleKeyInfo keyInfo, CancellationToken cancellationToken)
+    Task<KeyPress> IPromptCallbacks.TransformKeyPressAsync(string text, int caret, KeyPress keyPress, CancellationToken cancellationToken)
     {
         Debug.Assert(caret >= 0 && caret <= text.Length);
 
-        return InterpretKeyPressAsInputSubmitAsync(text, caret, keyInfo, cancellationToken);
+        return TransformKeyPressAsync(text, caret, keyPress, cancellationToken);
     }
 
 
@@ -234,7 +233,7 @@ public class PromptCallbacks : IPromptCallbacks
         return Task.FromResult(caret - 2 >= 0 && char.IsWhiteSpace(text[caret - 2]) && char.IsLetter(text[caret - 1]));
     }
 
-    /// <inheritdoc cref="IPromptCallbacks.InterpretKeyPressAsInputSubmitAsync"/>
-    protected virtual Task<bool> InterpretKeyPressAsInputSubmitAsync(string text, int caret, ConsoleKeyInfo keyInfo, CancellationToken cancellationToken)
-        => Task.FromResult(false);
+    /// <inheritdoc cref="IPromptCallbacks.TransformKeyPressAsync(string, int, KeyPress, CancellationToken)"/>
+    protected virtual Task<KeyPress> TransformKeyPressAsync(string text, int caret, KeyPress keyPress, CancellationToken cancellationToken)
+        => Task.FromResult(keyPress);
 }

--- a/tests/PrettyPrompt.Tests/TestPromptCallbacks.cs
+++ b/tests/PrettyPrompt.Tests/TestPromptCallbacks.cs
@@ -13,7 +13,7 @@ internal delegate Task<TextSpan> SpanToReplaceByCompletionCallbackAsync(string t
 internal delegate Task<IReadOnlyList<CompletionItem>> CompletionCallbackAsync(string text, int caret, TextSpan spanToBeReplaced);
 internal delegate Task<bool> OpenCompletionWindowCallbackAsync(string text, int caret);
 internal delegate Task<IReadOnlyCollection<FormatSpan>> HighlightCallbackAsync(string text);
-internal delegate Task<bool> InterpretKeyPressAsInputSubmitCallbackAsync(string text, int caret, ConsoleKeyInfo keyInfo);
+internal delegate Task<KeyPress> TransformKeyPressAsyncCallbackAsync(string text, int caret, KeyPress keyPress);
 
 internal class TestPromptCallbacks : PromptCallbacks
 {
@@ -23,7 +23,7 @@ internal class TestPromptCallbacks : PromptCallbacks
     public CompletionCallbackAsync? CompletionCallback { get; set; }
     public OpenCompletionWindowCallbackAsync? OpenCompletionWindowCallback { get; set; }
     public HighlightCallbackAsync? HighlightCallback { get; set; }
-    public InterpretKeyPressAsInputSubmitCallbackAsync? InterpretKeyPressAsInputSubmitCallback { get; set; }
+    public TransformKeyPressAsyncCallbackAsync? TransformKeyPressCallback { get; set; }
 
     public TestPromptCallbacks(params (KeyPressPattern Pattern, KeyPressCallbackAsync Callback)[]? keyPressCallbacks)
     {
@@ -64,11 +64,11 @@ internal class TestPromptCallbacks : PromptCallbacks
             HighlightCallback(text);
     }
 
-    protected override Task<bool> InterpretKeyPressAsInputSubmitAsync(string text, int caret, ConsoleKeyInfo keyInfo, CancellationToken cancellationToken)
+    protected override Task<KeyPress> TransformKeyPressAsync(string text, int caret, KeyPress keyPress, CancellationToken cancellationToken)
     {
         return
-            InterpretKeyPressAsInputSubmitCallback is null ?
-            base.InterpretKeyPressAsInputSubmitAsync(text, caret, keyInfo, cancellationToken) :
-            InterpretKeyPressAsInputSubmitCallback(text, caret, keyInfo);
+            TransformKeyPressCallback is null ?
+            base.TransformKeyPressAsync(text, caret, keyPress, cancellationToken) :
+            TransformKeyPressCallback(text, caret, keyPress);
     }
 }


### PR DESCRIPTION
This is needed to be able to fix https://github.com/waf/CSharpRepl/issues/68.

@waf could you please publish a new nuget version (3.0.1)? Unfortunately, I needed to fix something here.

It's API change but I doubt anyone apart from CSharpRepl used this.