### PR TITLE
MeasureConsole minor improvements + simplified usage

### DIFF
--- a/src/PrettyPrompt/Panes/CodePane.cs
+++ b/src/PrettyPrompt/Panes/CodePane.cs
@@ -23,13 +23,13 @@ namespace PrettyPrompt.Panes;
 
 internal class CodePane : IKeyPressHandler
 {
+    private readonly IConsole console;
     private readonly PromptConfiguration configuration;
-    private readonly IPromptCallbacks promptCallbacks;
     private readonly IClipboard clipboard;
     private readonly SelectionKeyPressHandler selectionHandler;
     private int topCoordinate;
-    private int codeAreaWidth = int.MaxValue;
-    private int codeAreaHeight = int.MaxValue;
+    private int codeAreaWidth;
+    private int codeAreaHeight;
     private int windowTop;
     private WordWrappedText wordWrappedText;
 
@@ -93,15 +93,18 @@ internal class CodePane : IKeyPressHandler
 
     public string TabSpaces { get; }
 
-    public CodePane(int topCoordinate, PromptConfiguration configuration, IPromptCallbacks promptCallbacks, IClipboard clipboard)
+    public CodePane(IConsole console, PromptConfiguration configuration, IClipboard clipboard)
     {
-        this.TopCoordinate = topCoordinate;
+        this.console = console;
         this.configuration = configuration;
-        this.promptCallbacks = promptCallbacks;
         this.clipboard = clipboard;
-        this.Document = new Document();
-        this.Document.Changed += WordWrap;
-        this.selectionHandler = new SelectionKeyPressHandler(this);
+
+        TopCoordinate = console.CursorTop;
+        MeasureConsole();
+
+        Document = new Document();
+        Document.Changed += WordWrap;
+        selectionHandler = new SelectionKeyPressHandler(this);
         TabSpaces = new string(' ', configuration.TabSize);
 
         WordWrap();
@@ -304,13 +307,13 @@ internal class CodePane : IKeyPressHandler
         }
     }
 
-    internal void MeasureConsole(IConsole console, int promptLength)
+    internal void MeasureConsole()
     {
         var windowTopChange = console.WindowTop - this.windowTop;
         this.TopCoordinate = Math.Max(0, this.TopCoordinate - windowTopChange);
         this.windowTop = console.WindowTop;
 
-        this.CodeAreaWidth = Math.Max(0, console.BufferWidth - promptLength);
+        this.CodeAreaWidth = Math.Max(0, console.BufferWidth - configuration.Prompt.Length);
         this.CodeAreaHeight = Math.Max(0, console.WindowHeight - this.TopCoordinate);
     }
 

--- a/src/PrettyPrompt/Prompt.cs
+++ b/src/PrettyPrompt/Prompt.cs
@@ -64,8 +64,7 @@ public sealed class Prompt : IPrompt
         renderer.RenderPrompt();
 
         // code pane contains the code the user is typing. It does not include the prompt (i.e. "> ")
-        var codePane = new CodePane(topCoordinate: console.CursorTop, configuration, promptCallbacks, clipboard);
-        codePane.MeasureConsole(console, configuration.Prompt.Length);
+        var codePane = new CodePane(console, configuration, clipboard);
 
         // completion pane is the pop-up window that shows potential autocompletions.
         var completionPane = new CompletionPane(
@@ -79,12 +78,12 @@ public sealed class Prompt : IPrompt
         foreach (var key in KeyPress.ReadForever(console))
         {
             // grab the code area width every key press, so we rerender appropriately when the console is resized.
-            codePane.MeasureConsole(console, configuration.Prompt.Length);
+            codePane.MeasureConsole();
 
             await InterpretKeyPress(key, codePane, completionPane, cancellationToken: default).ConfigureAwait(false);
 
             // typing / word-wrapping may have scrolled the console, giving us more room.
-            codePane.MeasureConsole(console, configuration.Prompt.Length);
+            codePane.MeasureConsole();
 
             // render the typed input, with syntax highlighting
             var inputText = codePane.Document.GetText();

--- a/src/PrettyPrompt/Rendering/Renderer.cs
+++ b/src/PrettyPrompt/Rendering/Renderer.cs
@@ -87,7 +87,7 @@ internal class Renderer
                 console.Clear(); // for some reason, using escape codes (ClearEntireScreen and MoveCursorToPosition) leaves
                                  // CursorTop in an old (cached?) state. Using Console.Clear() works around this.
                 RenderPrompt();
-                codePane.MeasureConsole(console, configuration.Prompt.Length); // our code pane will have more room to render, it now renders at the top of the screen.
+                codePane.MeasureConsole(); // our code pane will have more room to render, it now renders at the top of the screen.
             }
 
             await Redraw(cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Could cause OutOfMemory exception when Document was non-empty when constructing CodePane.