### PR TITLE
More corrections for UnicodeWidth.GetWidth.

### DIFF
--- a/src/PrettyPrompt/Rendering/UnicodeWidth.cs
+++ b/src/PrettyPrompt/Rendering/UnicodeWidth.cs
@@ -208,8 +208,20 @@ public static class UnicodeWidth
         if (BinarySearch(character, combining))
             return 0;
 
-        //PrettyPrompt's correction for black⚫/white⚪/empty⭕ circle
-        if ((int)character is 0x26AA or 0x26AB or 0x2B55) return 2;
+        //PrettyPrompt's correction
+        if ((int)character is
+            0x26AA or //⚫
+            0x26AB or //⚪
+            0x2B55 or //⭕
+            0x26A1 or //⚡
+            0x2B1B or //⬛
+            0x2B1C or //⬜
+            0x274C or //❌
+            0x2705    //✅
+            )
+        {
+            return 2;
+        }
 
         /* if we arrive here, ucs is not a combining or C0/C1 control character */
         return (character >= 0x1100 &&

--- a/tests/PrettyPrompt.Tests/ScreenTests.cs
+++ b/tests/PrettyPrompt.Tests/ScreenTests.cs
@@ -22,7 +22,8 @@ public class ScreenTests
     [InlineData("a😉bc", 5)]
     [InlineData("a😐🙄bc", 7)]
 
-    //different circles (some had incorrectly specified width in UnicodeWidth.GetWidth)
+    //different emojis (some had incorrectly specified width in UnicodeWidth.GetWidth)
+    //circles
     [InlineData("⚪", 2)]
     [InlineData("⚫", 2)]
     [InlineData("⭕", 2)]
@@ -33,6 +34,25 @@ public class ScreenTests
     [InlineData("🟢", 2)]
     [InlineData("🟣", 2)]
     [InlineData("🟤", 2)]
+
+    [InlineData("⚡", 2)]
+    [InlineData("💡", 2)]
+    [InlineData("❌", 2)]
+    [InlineData("✅", 2)]
+    
+    //squares
+    [InlineData("⬛", 2)]
+    [InlineData("🟫", 2)]
+    [InlineData("🟪", 2)]
+    [InlineData("🟦", 2)]
+    [InlineData("🟩", 2)]
+    [InlineData("🟨", 2)]
+    [InlineData("🟧", 2)]
+    [InlineData("🟥", 2)]
+    [InlineData("⬜", 2)]
+
+    [InlineData("🔷", 2)]
+    [InlineData("🔶", 2)]
     public void ScreenCursorPositionTest(string text, int expectedCursorPosition)
     {
         var screen = new Screen(


### PR DESCRIPTION
For symbols, I might want to use in CSharpRepl.

In the future, this should be done more systematically.