### PR TITLE
Fix of crash when repeating deleting selected text and Ctrl+Z.

### DIFF
--- a/src/PrettyPrompt/Documents/UndoRedoHistory.cs
+++ b/src/PrettyPrompt/Documents/UndoRedoHistory.cs
@@ -14,7 +14,7 @@ namespace PrettyPrompt.Documents;
 /// Stores undo/redo history for a single document.
 /// </summary>
 /// <remarks>
-/// Implementation is naive -- it just stores full snapshots in a linked and undo/redo navigates
+/// Implementation is naive -- it just stores full snapshots in a list and undo/redo navigates
 /// through it. If tracking snapshots of the input ends up causing high memory, we can rework it.
 /// </remarks>
 internal sealed class UndoRedoHistory
@@ -45,7 +45,7 @@ internal sealed class UndoRedoHistory
             {
                 //edit after undos -> we will throw following redos away
                 var itemsToRemove = history.Count - currentIndex - 1;
-                history.RemoveRange(1, itemsToRemove);
+                history.RemoveRange(index: history.Count - itemsToRemove, itemsToRemove);
             }
 
             history.Add(new Record(text.ToString(), caret, selection));

--- a/tests/PrettyPrompt.Tests/UndoRedoTests.cs
+++ b/tests/PrettyPrompt.Tests/UndoRedoTests.cs
@@ -362,4 +362,26 @@ public class UndoRedoTests
             Assert.Equal("a|d", result.Text);
         }
     }
+
+    /// <summary>
+    /// Reproduces bug from https://github.com/waf/PrettyPrompt/issues/133
+    /// </summary>
+    [Fact]
+    public async Task ReadLine_Repeated_CtrlZ_Backspace()
+    {
+        var console = ConsoleStub.NewConsole();
+        console.StubInput(
+            $"abcd",
+            $"{Shift}{LeftArrow}{Shift}{LeftArrow}", //select 'cd'
+            $"{Backspace}",
+            $"{Control}{Z}",
+            $"{Backspace}",
+            $"{Control}{Z}",
+            $"{Enter}"
+        );
+        var prompt = new Prompt(console: console);
+        var result = await prompt.ReadLineAsync();
+        Assert.True(result.IsSuccess);
+        Assert.Equal("abcd", result.Text);
+    }
 }


### PR DESCRIPTION
Resolves #133.