### PR TITLE
Fix of UndoRedoHistory assert failure while cutting text (#148)

### DIFF
--- a/src/PrettyPrompt/Panes/CodePane.cs
+++ b/src/PrettyPrompt/Panes/CodePane.cs
@@ -189,6 +189,7 @@ internal class CodePane : IKeyPressHandler
             case (Control, X) when selection.TryGet(out var selectionValue):
                 {
                     var cutContent = Document.GetText(selectionValue).ToString();
+                    Selection = null;
                     Document.Remove(this, selectionValue);
                     await clipboard.SetTextAsync(cutContent, cancellationToken).ConfigureAwait(false);
                     break;

--- a/src/PrettyPrompt/Panes/CompletionPane.cs
+++ b/src/PrettyPrompt/Panes/CompletionPane.cs
@@ -188,7 +188,7 @@ internal class CompletionPane : IKeyPressHandler
         {
             if (!char.IsControl(key.ConsoleKeyInfo.KeyChar) &&
                 !completionListTriggeredOnKeyDown &&
-                await promptCallbacks.ShouldOpenCompletionWindowAsync(codePane.Document.GetText(), codePane.Document.Caret, cancellationToken).ConfigureAwait(false))
+                await promptCallbacks.ShouldOpenCompletionWindowAsync(codePane.Document.GetText(), codePane.Document.Caret, key, cancellationToken).ConfigureAwait(false))
             {
                 Open();
             }

--- a/src/PrettyPrompt/PromptCallbacks.cs
+++ b/src/PrettyPrompt/PromptCallbacks.cs
@@ -86,9 +86,10 @@ public interface IPromptCallbacks
     /// </summary>
     /// <param name="text">The user's input text</param>
     /// <param name="caret">The index of the text caret in the input text</param>
+    /// <param name="keyPress">Key press after which we are asking whether completion list should be automatically open.</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>A value indicating whether the completion window should automatically open.</returns>
-    Task<bool> ShouldOpenCompletionWindowAsync(string text, int caret, CancellationToken cancellationToken);
+    Task<bool> ShouldOpenCompletionWindowAsync(string text, int caret, KeyPress keyPress, CancellationToken cancellationToken);
 
     /// <summary>
     /// Optionaly transforms key presses to another ones.
@@ -146,11 +147,11 @@ public class PromptCallbacks : IPromptCallbacks
         return GetCompletionItemsAsync(text, caret, spanToBeReplaced, cancellationToken);
     }
 
-    Task<bool> IPromptCallbacks.ShouldOpenCompletionWindowAsync(string text, int caret, CancellationToken cancellationToken)
+    Task<bool> IPromptCallbacks.ShouldOpenCompletionWindowAsync(string text, int caret, KeyPress keyPress, CancellationToken cancellationToken)
     {
         Debug.Assert(caret >= 0 && caret <= text.Length);
 
-        return ShouldOpenCompletionWindowAsync(text, caret, cancellationToken);
+        return ShouldOpenCompletionWindowAsync(text, caret, keyPress, cancellationToken);
     }
 
     Task<KeyPress> IPromptCallbacks.TransformKeyPressAsync(string text, int caret, KeyPress keyPress, CancellationToken cancellationToken)
@@ -216,7 +217,7 @@ public class PromptCallbacks : IPromptCallbacks
         => Task.FromResult<IReadOnlyList<CompletionItem>>(Array.Empty<CompletionItem>());
 
     /// <inheritdoc cref="IPromptCallbacks.ShouldOpenCompletionWindowAsync"/>
-    protected virtual Task<bool> ShouldOpenCompletionWindowAsync(string text, int caret, CancellationToken cancellationToken)
+    protected virtual Task<bool> ShouldOpenCompletionWindowAsync(string text, int caret, KeyPress keyPress, CancellationToken cancellationToken)
     {
         if (caret > 0 && text[caret - 1] is '.' or '(') // typical "intellisense behavior", opens for new methods and parameters
         {

--- a/tests/PrettyPrompt.Tests/TestPromptCallbacks.cs
+++ b/tests/PrettyPrompt.Tests/TestPromptCallbacks.cs
@@ -48,11 +48,11 @@ internal class TestPromptCallbacks : PromptCallbacks
             CompletionCallback(text, caret, spanToBeReplaced);
     }
 
-    protected override Task<bool> ShouldOpenCompletionWindowAsync(string text, int caret, CancellationToken cancellationToken)
+    protected override Task<bool> ShouldOpenCompletionWindowAsync(string text, int caret, KeyPress key, CancellationToken cancellationToken)
     {
         return
             OpenCompletionWindowCallback is null ?
-            base.ShouldOpenCompletionWindowAsync(text, caret, cancellationToken) :
+            base.ShouldOpenCompletionWindowAsync(text, caret, key, cancellationToken) :
             OpenCompletionWindowCallback(text, caret);
     }
 

--- a/tests/PrettyPrompt.Tests/UndoRedoTests.cs
+++ b/tests/PrettyPrompt.Tests/UndoRedoTests.cs
@@ -384,4 +384,23 @@ public class UndoRedoTests
         Assert.True(result.IsSuccess);
         Assert.Equal("abcd", result.Text);
     }
+
+    /// <summary>
+    /// Reproduces bug from https://github.com/waf/PrettyPrompt/issues/148
+    /// </summary>
+    [Fact]
+    public async Task ReadLine_CtrlA_CtrlX()
+    {
+        var console = ConsoleStub.NewConsole();
+        console.StubInput(
+            $"abcd",
+            $"{Control}{A}",
+            $"{Control}{X}",
+            $"{Enter}"
+        );
+        var prompt = new Prompt(console: console);
+        var result = await prompt.ReadLineAsync();
+        Assert.True(result.IsSuccess);
+        Assert.Equal("", result.Text);
+    }
 }


### PR DESCRIPTION
Resolves (#148).