### PR TITLE
Fix of down arrow not working properly when last character is '\n' (#160)

### DIFF
--- a/src/PrettyPrompt/Documents/Document.cs
+++ b/src/PrettyPrompt/Documents/Document.cs
@@ -183,7 +183,7 @@ internal class Document : IEquatable<Document>
                 {
                     if (stringBuilder[i] == '\n')
                     {
-                        lineStart = Math.Min(i + 1, Length - 1);
+                        lineStart = Math.Min(i + 1, Length);
                         break;
                     }
                 }

--- a/src/PrettyPrompt/Documents/WordWrapping.cs
+++ b/src/PrettyPrompt/Documents/WordWrapping.cs
@@ -22,13 +22,15 @@ internal static class WordWrapping
     /// The caret index (as the input is a 1 dimensional string of text) is converted
     /// to a 2 dimensional coordinate in the wrapped text.
     /// </summary>
-    public static WordWrappedText WrapEditableCharacters(ReadOnlyStringBuilder input, int initialCaretPosition, int width)
+    public static WordWrappedText WrapEditableCharacters(ReadOnlyStringBuilder input, int caret, int width)
     {
+        Debug.Assert(caret >= 0 && caret <= input.Length);
+
         if (input.Length == 0)
         {
             return new WordWrappedText(
                 new[] { WrappedLine.Empty(startIndex: 0) },
-                new ConsoleCoordinate(0, initialCaretPosition));
+                new ConsoleCoordinate(0, caret));
         }
 
         var lines = new List<WrappedLine>();
@@ -44,7 +46,7 @@ internal static class WordWrapping
             {
                 char character = chunk[i];
                 line.Append(character);
-                bool isCursorPastCharacter = initialCaretPosition > textIndex;
+                bool isCursorPastCharacter = caret > textIndex;
 
                 Debug.Assert(character != '\t', "tabs should be replaced by spaces");
                 int unicodeWidth = UnicodeWidth.GetWidth(character);
@@ -75,7 +77,7 @@ internal static class WordWrapping
             }
         }
 
-        if (currentLineLength > 0)
+        if (currentLineLength > 0 || input[^1] == '\n')
         {
             lines.Add(new WrappedLine(textIndex - line.Length, line.ToString()));
         }
@@ -164,6 +166,8 @@ internal struct WordWrappedText
 
     public WordWrappedText(IReadOnlyList<WrappedLine> wrappedLines, ConsoleCoordinate cursor)
     {
+        Debug.Assert(!wrappedLines.Last().Content.EndsWith('\n'));
+
         WrappedLines = wrappedLines;
 
         this.cursor = default;

--- a/tests/PrettyPrompt.Tests/DocumentTests.cs
+++ b/tests/PrettyPrompt.Tests/DocumentTests.cs
@@ -187,4 +187,23 @@ public class DocumentTests
             Assert.Equal(4, document.Caret);
         }
     }
+
+    /// <summary>
+    /// Triggers bug from https://github.com/waf/PrettyPrompt/issues/161.
+    /// </summary>
+    [Fact]
+    public void LeftMoveToLineBoundary_OnEmptyLine_ShouldDoNothing()
+    {
+        var document = new Document("abc\n", caret: 4);
+        document.MoveToLineBoundary(-1);
+        Assert.Equal(4, document.Caret);
+
+        document = new Document("abc\n\n", caret: 4);
+        document.MoveToLineBoundary(-1);
+        Assert.Equal(4, document.Caret);
+
+        document.Caret = 5;
+        document.MoveToLineBoundary(-1);
+        Assert.Equal(5, document.Caret);
+    }
 }

--- a/tests/PrettyPrompt.Tests/PromptTests.cs
+++ b/tests/PrettyPrompt.Tests/PromptTests.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using NSubstitute;
 using PrettyPrompt.Consoles;
-using PrettyPrompt.Documents;
 using PrettyPrompt.Highlighting;
 using Xunit;
 using static System.ConsoleKey;
@@ -22,7 +21,7 @@ namespace PrettyPrompt.Tests;
 
 public class PromptTests
 {
-    private static readonly string DefaultTabSpaces= new(' ', new PromptConfiguration().TabSize);
+    private static readonly string DefaultTabSpaces = new(' ', new PromptConfiguration().TabSize);
 
     [Fact]
     public async Task ReadLine_TypeSimpleString_GetSimpleString()
@@ -155,6 +154,22 @@ public class PromptTests
         var result = await prompt.ReadLineAsync();
 
         Assert.Equal($"pretty well{NewLine}unit-tested?{NewLine}prompt!", result.Text);
+    }
+
+    /// <summary>
+    /// Triggered bug from https://github.com/waf/PrettyPrompt/issues/160.
+    /// </summary>
+    [Fact]
+    public async Task ReadLine_ArrowDownToLastEmptyLine()
+    {
+        var console = ConsoleStub.NewConsole();
+        console.StubInput($"abc{Shift}{Enter}{LeftArrow}{DownArrow}x{Enter}");
+
+        var prompt = new Prompt(console: console);
+        var result = await prompt.ReadLineAsync();
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal($"abc{NewLine}x", result.Text);
     }
 
     [Fact]

--- a/tests/PrettyPrompt.Tests/WordWrappingTests.cs
+++ b/tests/PrettyPrompt.Tests/WordWrappingTests.cs
@@ -31,7 +31,7 @@ public class WordWrappingTests
     public void WrapEditableCharacters_DoubleWidthCharacters_UsesStringWidth()
     {
         var text = "每个人都有他的作战策略，直到脸上中了一拳。";
-        var wrapped = WordWrapping.WrapEditableCharacters(new StringBuilder(text), initialCaretPosition: 13, width: 20);
+        var wrapped = WordWrapping.WrapEditableCharacters(new StringBuilder(text), caret: 13, width: 20);
 
         Assert.Equal(
             new[]
@@ -50,7 +50,7 @@ public class WordWrappingTests
     public void WrapEditableCharacters_DoubleWidthCharactersWithWrappingInMiddleOfCharacter_WrapsCharacter()
     {
         var text = "每个人都有他的作战策略， 直到脸上中了一拳。";
-        var wrapped = WordWrapping.WrapEditableCharacters(new StringBuilder(text), initialCaretPosition: 19, width: 19);
+        var wrapped = WordWrapping.WrapEditableCharacters(new StringBuilder(text), caret: 19, width: 19);
 
         Assert.Equal(
             new[]


### PR DESCRIPTION
Resolves #160.