### PR TITLE
Improved selection formatting + it's configurable (#155)

### DIFF
--- a/examples/PrettyPrompt.Examples.FruitPrompt/Program.cs
+++ b/examples/PrettyPrompt.Examples.FruitPrompt/Program.cs
@@ -24,7 +24,8 @@ internal static class Program
             configuration: new PromptConfiguration(
                 prompt: new FormattedString(">>> ", new FormatSpan(0, 1, AnsiColor.Red), new FormatSpan(1, 1, AnsiColor.Yellow), new FormatSpan(2, 1, AnsiColor.Green)),
                 completionItemDescriptionPaneBackground: AnsiColor.Rgb(30, 30, 30),
-                selectedCompletionItemBackground: AnsiColor.Rgb(30, 30, 30)));
+                selectedCompletionItemBackground: AnsiColor.Rgb(30, 30, 30),
+                selectedTextBackground: AnsiColor.Rgb(20, 61, 102)));
         while (true)
         {
             var response = await prompt.ReadLineAsync().ConfigureAwait(false);

--- a/src/PrettyPrompt/Highlighting/CellRenderer.cs
+++ b/src/PrettyPrompt/Highlighting/CellRenderer.cs
@@ -19,7 +19,7 @@ namespace PrettyPrompt.Highlighting;
 /// </summary>
 internal static class CellRenderer
 {
-    public static Row[] ApplyColorToCharacters(IReadOnlyCollection<FormatSpan> highlights, IReadOnlyList<WrappedLine> lines, SelectionSpan? selection)
+    public static Row[] ApplyColorToCharacters(IReadOnlyCollection<FormatSpan> highlights, IReadOnlyList<WrappedLine> lines, SelectionSpan? selection, AnsiColor? selectedTextBackground)
     {
         var selectionStart = new ConsoleCoordinate(int.MaxValue, int.MaxValue); //invalid
         var selectionEnd = new ConsoleCoordinate(int.MaxValue, int.MaxValue); //invalid
@@ -76,7 +76,14 @@ internal static class CellRenderer
                 }
                 if (selectionHighlight)
                 {
-                    cell.Formatting = new ConsoleFormat { Inverted = true };
+                    if (selectedTextBackground.TryGet(out var background))
+                    {
+                        cell.Formatting = cell.Formatting with { Background = background };
+                    }
+                    else
+                    {
+                        cell.Formatting = new ConsoleFormat { Inverted = true };
+                    }
                 }
             }
             highlightedRows[lineIndex] = new Row(cells);
@@ -108,6 +115,6 @@ internal static class CellRenderer
     public static Row[] ApplyColorToCharacters(IReadOnlyCollection<FormatSpan> highlights, string text, int textWidth)
     {
         var wrapped = WordWrapping.WrapEditableCharacters(new StringBuilder(text), 0, textWidth);
-        return ApplyColorToCharacters(highlights, wrapped.WrappedLines, null);
+        return ApplyColorToCharacters(highlights, wrapped.WrappedLines, selection: null, selectedTextBackground: null);
     }
 }

--- a/src/PrettyPrompt/PromptConfiguration.cs
+++ b/src/PrettyPrompt/PromptConfiguration.cs
@@ -26,10 +26,10 @@ public class PromptConfiguration
 
     public ConsoleFormat CompletionBoxBorderFormat { get; }
     public AnsiColor? CompletionItemDescriptionPaneBackground { get; }
-
     public FormattedString SelectedCompletionItemMarker { get; }
     public string UnselectedCompletionItemMarker { get; }
     public AnsiColor? SelectedCompletionItemBackground { get; }
+    public AnsiColor? SelectedTextBackground { get; }
 
     /// <summary>
     /// How few completion items we are willing to render. If we do not have a space for rendering of
@@ -53,6 +53,7 @@ public class PromptConfiguration
         AnsiColor? completionItemDescriptionPaneBackground = null,
         FormattedString? selectedCompletionItemMarkSymbol = null,
         AnsiColor? selectedCompletionItemBackground = null,
+        AnsiColor? selectedTextBackground = null,
         int minCompletionItemsCount = 1,
         int maxCompletionItemsCount = 9, //9 is VS default
         double proportionOfWindowHeightForCompletionPane = 0.9,
@@ -71,6 +72,7 @@ public class PromptConfiguration
         SelectedCompletionItemMarker = selectedCompletionItemMarkSymbol ?? new FormattedString(">", new FormatSpan(0, 1, AnsiColor.Cyan));
         UnselectedCompletionItemMarker = new string(' ', SelectedCompletionItemMarker.Length);
         SelectedCompletionItemBackground = GetColor(selectedCompletionItemBackground);
+        SelectedTextBackground = GetColor(selectedTextBackground);
 
         ConsoleFormat GetFormat(ConsoleFormat format) => HasUserOptedOutFromColor ? ConsoleFormat.None : format;
         AnsiColor? GetColor(AnsiColor? color) => HasUserOptedOutFromColor ? null : color;

--- a/src/PrettyPrompt/Rendering/Renderer.cs
+++ b/src/PrettyPrompt/Rendering/Renderer.cs
@@ -146,9 +146,9 @@ internal class Renderer
     private static bool DidCodeAreaResize(Screen previousScreen, Screen currentScreen) =>
         previousScreen != null && previousScreen?.Width != currentScreen.Width;
 
-    private static ScreenArea BuildCodeScreenArea(CodePane codePane, IReadOnlyCollection<FormatSpan> highlights)
+    private ScreenArea BuildCodeScreenArea(CodePane codePane, IReadOnlyCollection<FormatSpan> highlights)
     {
-        var highlightedLines = CellRenderer.ApplyColorToCharacters(highlights, codePane.WordWrappedLines, codePane.Selection);
+        var highlightedLines = CellRenderer.ApplyColorToCharacters(highlights, codePane.WordWrappedLines, codePane.Selection, configuration.SelectedTextBackground);
         // if we've filled up the full line, add a new line at the end so we can render our cursor on this new line.
         if (highlightedLines[^1].Cells.Count > 0
             && (highlightedLines[^1].Cells.Count >= codePane.CodeAreaWidth


### PR DESCRIPTION
Resolves #155.

Before:
![image](https://user-images.githubusercontent.com/11704036/159120875-a605cbba-5441-4088-a6f7-07be1651d365.png)

After:
![image](https://user-images.githubusercontent.com/11704036/159120930-8056b332-d5d7-4bc7-a72e-962c57c809af.png)