### PR TITLE
Delete line (#152).

### DIFF
--- a/src/PrettyPrompt/Panes/CodePane.cs
+++ b/src/PrettyPrompt/Panes/CodePane.cs
@@ -194,7 +194,7 @@ internal class CodePane : IKeyPressHandler
                     await clipboard.SetTextAsync(cutContent, cancellationToken).ConfigureAwait(false);
                     break;
                 }
-            case (Control, X):
+            case (Control, X) or (Shift, Delete):
                 {
                     var lineStart = Document.CalculateLineBoundaryIndexNearCaret(-1, smartHome: false);
                     var lineEnd = Document.CalculateLineBoundaryIndexNearCaret(1, smartHome: false);
@@ -204,7 +204,12 @@ internal class CodePane : IKeyPressHandler
                         Debug.Assert(Document.GetText()[span.End] == '\n');
                         span = new TextSpan(span.Start, span.Length + 1);
                     }
-                    await clipboard.SetTextAsync(Document.GetText(span).ToString(), cancellationToken).ConfigureAwait(false);
+
+                    if (key.ObjectPattern is (Control, X))
+                    {
+                        await clipboard.SetTextAsync(Document.GetText(span).ToString(), cancellationToken).ConfigureAwait(false); 
+                    }
+
                     Document.Remove(this, span);
                     break;
                 }

--- a/tests/PrettyPrompt.Tests/ConsoleStub.cs
+++ b/tests/PrettyPrompt.Tests/ConsoleStub.cs
@@ -20,7 +20,7 @@ namespace PrettyPrompt.Tests;
 internal static class ConsoleStub
 {
     private static readonly Regex FormatStringSplit = new(@"({\d+}|.)", RegexOptions.Compiled);
-    private static readonly Mutex mutex = new(initiallyOwned: false, nameof(ConsoleStub) + "Mutex"); //interprocess
+    private static readonly Semaphore semaphore = new(1, 1, nameof(ConsoleStub) + "Semaphore"); //interprocess
 
     public static IConsoleWithClipboard NewConsole(int width = 100, int height = 100)
     {
@@ -32,7 +32,7 @@ internal static class ConsoleStub
         console.ProtectClipboard().Returns(
             _ =>
             {
-                mutex.WaitOne();
+                semaphore.WaitOne();
                 return new MutexProtector();
             });
 
@@ -230,6 +230,6 @@ internal static class ConsoleStub
 
     private class MutexProtector : IDisposable
     {
-        public void Dispose() => mutex.ReleaseMutex();
+        public void Dispose() => semaphore.Release();
     }
 }


### PR DESCRIPTION
Resolves #152.

Fix of clipboard protection in unit tests from async methods (mutex was failing when releasing was done from a different thread).