### PR TITLE
Remove indentation of pasted text only when there are multiple non-whitespace lines (#168).

### DIFF
--- a/src/PrettyPrompt/Panes/CodePane.cs
+++ b/src/PrettyPrompt/Panes/CodePane.cs
@@ -284,24 +284,34 @@ internal class CodePane : IKeyPressHandler
             if (lines.Length > 1)
             {
                 var nonEmptyLines = lines
-                    .Where(line => line.Length > 0)
+                    .Where(line => !string.IsNullOrWhiteSpace(line))
                     .ToList();
 
-                if (!nonEmptyLines.Any())
+                //we remove indentation only when there are multiple non-whitespace lines
+                if (nonEmptyLines.Count <= 1)
                 {
                     AppendFiltered(sb, text);
-                    return sb.ToString();
                 }
-
-                var leadingIndent = nonEmptyLines
-                    .Select(line => line.TakeWhile(char.IsWhiteSpace).Count())
-                    .Min();
-
-                for (var i = 0; i < lines.Length; i++)
+                else
                 {
-                    var line = lines[i].Substring(Math.Min(lines[i].Length, leadingIndent));
-                    AppendFiltered(sb, line);
-                    if (i != lines.Length - 1) sb.Append('\n');
+                    var leadingIndent = nonEmptyLines
+                        .Select(line => line.TakeWhile(char.IsWhiteSpace).Count())
+                        .Min();
+
+                    if (leadingIndent == 0)
+                    {
+                        AppendFiltered(sb, text);
+                    }
+                    else
+                    {
+                        //removing indentation
+                        for (var i = 0; i < lines.Length; i++)
+                        {
+                            var line = lines[i][Math.Min(lines[i].Length, leadingIndent)..];
+                            AppendFiltered(sb, line);
+                            if (i != lines.Length - 1) sb.Append('\n');
+                        }
+                    }
                 }
             }
             else

--- a/tests/PrettyPrompt.Tests/PromptTests.cs
+++ b/tests/PrettyPrompt.Tests/PromptTests.cs
@@ -262,6 +262,48 @@ public class PromptTests
         Assert.Equal($"indent{NewLine}    more indent{NewLine}{NewLine}indent", result.Text);
     }
 
+    /// <summary>
+    /// https://github.com/waf/PrettyPrompt/issues/168
+    /// </summary>
+    [Fact]
+    public async Task ReadLine_Paste_DoesNotTrimLeadingIndentation()
+    {
+        var console = ConsoleStub.NewConsole();
+        using (console.ProtectClipboard())
+        {
+            console.Clipboard.SetText("    abcd");
+            console.StubInput($"{Control}{V}{Enter}");
+            var prompt = new Prompt(console: console);
+            var result = await prompt.ReadLineAsync();
+            Assert.Equal($"    abcd", result.Text);
+
+            ///////////////////
+            
+            console.Clipboard.SetText("    abcd\n");
+            console.StubInput($"{Control}{V}{Enter}");
+            prompt = new Prompt(console: console);
+            result = await prompt.ReadLineAsync();
+            Assert.Equal($"    abcd{NewLine}", result.Text);
+
+            ///////////////////
+
+            console.Clipboard.SetText("\n    abcd\n");
+            console.StubInput($"{Control}{V}{Enter}");
+            prompt = new Prompt(console: console);
+            result = await prompt.ReadLineAsync();
+            Assert.Equal($"{NewLine}    abcd{NewLine}", result.Text);
+
+
+            ///////////////////
+
+            console.Clipboard.SetText("\n    abcd\t\n");
+            console.StubInput($"{Control}{V}{Enter}");
+            prompt = new Prompt(console: console);
+            result = await prompt.ReadLineAsync();
+            Assert.Equal($"{NewLine}    abcd{DefaultTabSpaces}{NewLine}", result.Text);
+        }
+    }
+
     [Fact]
     public async Task ReadLine_KeyPressCallback_IsInvoked()
     {


### PR DESCRIPTION
Resolves #168.

Also adds automatic detection of unit tests using clipboard without protection.