### PR TITLE
CompletionItem.CommitCharacterRules

### DIFF
--- a/src/PrettyPrompt/Completion/CompletionItem.cs
+++ b/src/PrettyPrompt/Completion/CompletionItem.cs
@@ -5,9 +5,11 @@
 #endregion
 
 using System;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using PrettyPrompt.Consoles;
 using PrettyPrompt.Documents;
 using PrettyPrompt.Highlighting;
 
@@ -42,6 +44,11 @@ public class CompletionItem
     public string FilterText { get; }
 
     /// <summary>
+    /// Rules that modify the set of characters that can be typed to cause the selected item to be committed.
+    /// </summary>
+    public ImmutableArray<CharacterSetModificationRule> CommitCharacterRules { get; }
+
+    /// <summary>
     /// This task will be executed when the item is selected, to display the extended "tool tip" description to the right of the menu.
     /// </summary>
     public Task<FormattedString> GetExtendedDescriptionAsync(CancellationToken cancellationToken) => getExtendedDescription(cancellationToken);
@@ -52,15 +59,18 @@ public class CompletionItem
     /// <param name="displayText">This text will be displayed in the completion menu. If not specified, the <paramref name="replacementText"/> value will be used.</param>
     /// <param name="getExtendedDescription">This lazy task will be executed when the item is selected, to display the extended "tool tip" description to the right of the menu.</param>
     /// <param name="filterText">The text used to determine if the item matches the filter in the list. If not specified the <paramref name="replacementText"/> value is used.</param>
+    /// <param name="commitCharacterRules">Rules that modify the set of characters that can be typed to cause the selected item to be committed.</param>
     public CompletionItem(
         string replacementText,
         FormattedString displayText = default,
         string? filterText = null,
-        GetExtendedDescriptionHandler? getExtendedDescription = null)
+        GetExtendedDescriptionHandler? getExtendedDescription = null,
+        ImmutableArray<CharacterSetModificationRule> commitCharacterRules = default)
     {
         ReplacementText = replacementText;
         DisplayTextFormatted = displayText.IsEmpty ? replacementText : displayText;
         FilterText = filterText ?? replacementText;
+        CommitCharacterRules = commitCharacterRules.IsDefault ? ImmutableArray<CharacterSetModificationRule>.Empty : commitCharacterRules;
 
         Task<FormattedString>? extendedDescriptionTask = null; //will be stored in closure of getExtendedDescription
         this.getExtendedDescription = ct => extendedDescriptionTask ??= getExtendedDescription?.Invoke(ct) ?? Task.FromResult(FormattedString.Empty);

--- a/src/PrettyPrompt/Console/CharacterSetModificationKind.cs
+++ b/src/PrettyPrompt/Console/CharacterSetModificationKind.cs
@@ -1,0 +1,24 @@
+﻿namespace PrettyPrompt.Consoles;
+
+//analogue of Microsoft.CodeAnalysis.Completion.CharacterSetModificationKind
+
+/// <summary>
+/// The kind of character set modification.
+/// </summary>
+public enum CharacterSetModificationKind
+{
+    /// <summary>
+    /// The rule adds new characters onto the existing set of characters.
+    /// </summary>
+    Add,
+
+    /// <summary>
+    /// The rule removes characters from the existing set of characters.
+    /// </summary>
+    Remove,
+
+    /// <summary>
+    /// The rule replaces the existing set of characters.
+    /// </summary>
+    Replace
+}

--- a/src/PrettyPrompt/Console/CharacterSetModificationRule.cs
+++ b/src/PrettyPrompt/Console/CharacterSetModificationRule.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Immutable;
+
+namespace PrettyPrompt.Consoles;
+
+//analogue of Microsoft.CodeAnalysis.Completion.CharacterSetModificationRule
+
+/// <summary>
+/// A rule that modifies a set of characters.
+/// </summary>
+public readonly struct CharacterSetModificationRule
+{
+    /// <summary>
+    /// The kind of modification.
+    /// </summary>
+    public CharacterSetModificationKind Kind { get; }
+
+    /// <summary>
+    /// One or more characters.
+    /// </summary>
+    public ImmutableArray<char> Characters { get; }
+
+    public CharacterSetModificationRule(CharacterSetModificationKind kind, ImmutableArray<char> characters)
+    {
+        Kind = kind;
+        Characters = characters;
+    }
+}

--- a/src/PrettyPrompt/Console/KeyPressPattern.cs
+++ b/src/PrettyPrompt/Console/KeyPressPattern.cs
@@ -5,9 +5,11 @@
 #endregion
 
 using System;
+using System.Diagnostics;
 
 namespace PrettyPrompt.Consoles;
 
+[DebuggerDisplay("{" + nameof(GetDebuggerDisplay) + "()}")]
 public readonly struct KeyPressPattern
 {
     private readonly KeyPressPatternType type;
@@ -41,7 +43,19 @@ public readonly struct KeyPressPattern
         return
             type == KeyPressPatternType.ConsoleKey ?
             keyInfo.Modifiers == Modifiers && keyInfo.Key == Key :
-            keyInfo.Modifiers == default && keyInfo.KeyChar == Character;
+            (keyInfo.Modifiers is default(ConsoleModifiers) or ConsoleModifiers.Shift) && keyInfo.KeyChar == Character; //Shift is ok, it only determines casing of letter
+    }
+
+    private string GetDebuggerDisplay()
+    {
+        if (type == KeyPressPatternType.ConsoleKey)
+        {
+            return Modifiers == default ? $"{Key}" : $"{Modifiers}+{Key}";
+        }
+        else
+        {
+            return $"{Character}";
+        }
     }
 }
 

--- a/src/PrettyPrompt/Console/KeyPressPatterns.cs
+++ b/src/PrettyPrompt/Console/KeyPressPatterns.cs
@@ -5,6 +5,7 @@
 #endregion
 
 using System;
+using System.Collections.Immutable;
 
 namespace PrettyPrompt.Consoles;
 
@@ -23,13 +24,35 @@ public readonly struct KeyPressPatterns
     public bool Matches(ConsoleKeyInfo keyInfo)
     {
         if (definedPatterns is null) return false;
-        foreach (var definedPattern in definedPatterns)
+        foreach (var pattern in definedPatterns)
         {
-            if (definedPattern.Matches(keyInfo))
+            if (pattern.Matches(keyInfo))
             {
                 return true;
             }
         }
         return false;
+    }
+
+    public bool Matches(ConsoleKeyInfo keyInfo, ImmutableArray<CharacterSetModificationRule> modificationRules)
+    {
+        foreach (var rule in modificationRules)
+        {
+            switch (rule.Kind)
+            {
+                case CharacterSetModificationKind.Add:
+                    if (rule.Characters.Contains(keyInfo.KeyChar))
+                        return true;
+                    continue;
+                case CharacterSetModificationKind.Remove:
+                    if (rule.Characters.Contains(keyInfo.KeyChar))
+                        return false;
+                    continue;
+                case CharacterSetModificationKind.Replace:
+                    return rule.Characters.Contains(keyInfo.KeyChar);
+            }
+        }
+
+        return Matches(keyInfo);
     }
 }

--- a/src/PrettyPrompt/Panes/CompletionPane.cs
+++ b/src/PrettyPrompt/Panes/CompletionPane.cs
@@ -155,22 +155,22 @@ internal class CompletionPane : IKeyPressHandler
                 this.FilteredView.DecrementSelectedIndex();
                 key.Handled = true;
                 break;
-            case var _ when configuration.KeyBindings.CommitCompletion.Matches(key.ConsoleKeyInfo):
-                if (FilteredView.SelectedItem != null)
-                {
-                    await InsertCompletion(codePane, FilteredView.SelectedItem, cancellationToken).ConfigureAwait(false);
-                    key.Handled = char.IsControl(key.ConsoleKeyInfo.KeyChar);
-                }
-                else
-                {
-                    Close();
-                    break;
-                }
-                break;
             case var _ when configuration.KeyBindings.TriggerCompletionList.Matches(key.ConsoleKeyInfo):
                 key.Handled = true;
                 break;
             default:
+                if (FilteredView.SelectedItem is null)
+                {
+                    if (configuration.KeyBindings.CommitCompletion.Matches(key.ConsoleKeyInfo))
+                    {
+                        Close();
+                    }
+                }
+                else if (configuration.KeyBindings.CommitCompletion.Matches(key.ConsoleKeyInfo, FilteredView.SelectedItem.CommitCharacterRules))
+                {
+                    await InsertCompletion(codePane, FilteredView.SelectedItem, cancellationToken).ConfigureAwait(false);
+                    key.Handled = char.IsControl(key.ConsoleKeyInfo.KeyChar);
+                }
                 break;
         }
     }


### PR DESCRIPTION
`CompletionItem` can optionally specify `CommitCharacterRules` (analoguous to Roslyn's `CompletionItem`).