### PR TITLE
Disable history scrolling by UpArrow in multiline statements (#181).

### DIFF
--- a/src/PrettyPrompt/History/HistoryLog.cs
+++ b/src/PrettyPrompt/History/HistoryLog.cs
@@ -90,13 +90,20 @@ internal sealed class HistoryLog : IKeyPressHandler
 
         if (history.Count == 0 || key.Handled) return;
 
+        var contents = codePane.Document.GetText();
+        if (contents.Contains('\n'))
+        {
+            //we do not want to cycle in history in multiline documents
+            return;
+        }
+        
         switch (key.ObjectPattern)
         {
             case UpArrow:
                 if (currentIndex == -1)
                 {
                     currentIndex = history.Count - 1;
-                    unsubmittedBuffer.SetContents(codePane.Document.GetText());
+                    unsubmittedBuffer.SetContents(contents);
                 }
                 else if (currentIndex > 0)
                 {
@@ -189,7 +196,7 @@ internal sealed class HistoryLog : IKeyPressHandler
         if (history.Count == 0 || history[^1] != input) //filter out duplicates
         {
             var entry = Convert.ToBase64String(Encoding.UTF8.GetBytes(input));
-            await File.AppendAllLinesAsync(persistentHistoryFilepath, new[] { entry }).ConfigureAwait(false); 
+            await File.AppendAllLinesAsync(persistentHistoryFilepath, new[] { entry }).ConfigureAwait(false);
         }
     }
 }

--- a/tests/PrettyPrompt.Tests/HistoryTests.cs
+++ b/tests/PrettyPrompt.Tests/HistoryTests.cs
@@ -4,10 +4,12 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #endregion
 
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using Xunit;
 using static System.ConsoleKey;
+using static System.ConsoleModifiers;
 
 namespace PrettyPrompt.Tests;
 
@@ -256,5 +258,22 @@ public class HistoryTests
         {
             File.Delete(historyFile);
         }
+    }
+
+    /// <summary>
+    /// https://github.com/waf/PrettyPrompt/issues/181
+    /// </summary>
+    [Fact]
+    public async Task ReadLine_UpArrow_DoesNotCycleThroughHistory_InMultilineStatements()
+    {
+        var console = ConsoleStub.NewConsole();
+        var prompt = new Prompt(console: console);
+
+        console.StubInput($"a{Enter}");
+        await prompt.ReadLineAsync();
+
+        console.StubInput($"{Shift}{Enter}{UpArrow}{UpArrow}{UpArrow}{UpArrow}{UpArrow}b{Enter}");
+        var result = await prompt.ReadLineAsync();
+        Assert.Equal($"b{Environment.NewLine}", result.Text);
     }
 }


### PR DESCRIPTION
Resolves #181.