### PR TITLE
Map special characters in KeyPressPattern

### DIFF
--- a/src/PrettyPrompt/Console/KeyPressPattern.cs
+++ b/src/PrettyPrompt/Console/KeyPressPattern.cs
@@ -27,7 +27,7 @@ public readonly struct KeyPressPattern
         type = KeyPressPatternType.ConsoleKey;
         Modifiers = modifiers;
         Key = key;
-        Character = default;
+        Character = MapToCharacter(key);
     }
 
     public KeyPressPattern(char character)
@@ -44,6 +44,20 @@ public readonly struct KeyPressPattern
             type == KeyPressPatternType.ConsoleKey ?
             keyInfo.Modifiers == Modifiers && keyInfo.Key == Key :
             (keyInfo.Modifiers is default(ConsoleModifiers) or ConsoleModifiers.Shift) && keyInfo.KeyChar == Character; //Shift is ok, it only determines casing of letter
+    }
+
+    private static char MapToCharacter(ConsoleKey key)
+    {
+        var keyString = key.ToString();
+        return keyString switch
+        {
+            { Length: 1 } => keyString[0],
+            "Enter" => '\n',
+            "Spacebar" => ' ',
+            "Escape" => '\x1b',
+            "Tab" => '\t',
+            _ => '\0'
+        };
     }
 
     private string GetDebuggerDisplay()

--- a/src/PrettyPrompt/Console/KeyPressPatterns.cs
+++ b/src/PrettyPrompt/Console/KeyPressPatterns.cs
@@ -11,20 +11,20 @@ namespace PrettyPrompt.Consoles;
 
 public readonly struct KeyPressPatterns
 {
-    private readonly KeyPressPattern[]? definedPatterns;
+    public readonly KeyPressPattern[]? DefinedPatterns;
 
-    public bool HasAny => definedPatterns?.Length > 0;
+    public bool HasAny => DefinedPatterns?.Length > 0;
 
     public KeyPressPatterns(params KeyPressPattern[]? definedPatterns)
-        => this.definedPatterns = definedPatterns;
+        => this.DefinedPatterns = definedPatterns;
 
     public static implicit operator KeyPressPatterns(KeyPressPattern[]? definedPatterns)
         => new(definedPatterns);
 
     public bool Matches(ConsoleKeyInfo keyInfo)
     {
-        if (definedPatterns is null) return false;
-        foreach (var pattern in definedPatterns)
+        if (DefinedPatterns is null) return false;
+        foreach (var pattern in DefinedPatterns)
         {
             if (pattern.Matches(keyInfo))
             {


### PR DESCRIPTION
KeyPressPattern can either be a `ConsoleKey` or a `char` -- in the ConsoleKey case this PR adds a 'best effort' conversion of the ConsoleKey to a char. This is very similar to the [conversion that PSReadLine does](https://github.com/PowerShell/PSReadLine/blob/ad74cef2501709d2a60a58f61d7cac32d185209f/PSReadLine/Keys.cs#L31-L58), so although this is merely best effort I think it should be sufficient.

This change is ultimately required by CSharpRepl because the Roslyn Completion API works on characters ([example](https://github.com/dotnet/roslyn/blob/777f4e0a58eda195a6c66a0327267b16bbbf8f9d/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/Helpers.cs#L77-L134)), not ConsoleKey, so to do some configuration of the Roslyn Completion API we need to know the character that the user has configured for completion, not just the ConsoleKey.