### PR TITLE
Prompt benchmark.

### DIFF
--- a/PrettyPrompt.sln
+++ b/PrettyPrompt.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31019.35
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32328.378
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PrettyPrompt", "src\PrettyPrompt\PrettyPrompt.csproj", "{1F9726E2-DB89-4FD8-947A-F6CBFE885495}"
 EndProject
@@ -16,6 +16,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		nuget.config = nuget.config
 		README.md = README.md
 	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PrettyPrompt.Benchmarks", "tests\PrettyPrompt.Benchmarks\PrettyPrompt.Benchmarks.csproj", "{9C8B74CD-CD66-43DE-8B52-EEEEE91642C1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -35,6 +37,10 @@ Global
 		{C94F0EFC-9533-46F2-BD61-65231F939D52}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C94F0EFC-9533-46F2-BD61-65231F939D52}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C94F0EFC-9533-46F2-BD61-65231F939D52}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9C8B74CD-CD66-43DE-8B52-EEEEE91642C1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9C8B74CD-CD66-43DE-8B52-EEEEE91642C1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9C8B74CD-CD66-43DE-8B52-EEEEE91642C1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9C8B74CD-CD66-43DE-8B52-EEEEE91642C1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/examples/PrettyPrompt.Examples.FruitPrompt/PrettyPrompt.Examples.FruitPrompt.csproj
+++ b/examples/PrettyPrompt.Examples.FruitPrompt/PrettyPrompt.Examples.FruitPrompt.csproj
@@ -16,4 +16,10 @@
     <ProjectReference Include="..\..\src\PrettyPrompt\PrettyPrompt.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>PrettyPrompt.Benchmarks</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/examples/PrettyPrompt.Examples.FruitPrompt/Program.cs
+++ b/examples/PrettyPrompt.Examples.FruitPrompt/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -131,7 +132,7 @@ internal static class Program
         }
     }
 
-    private class FruitPromptCallbacks : PromptCallbacks
+    internal class FruitPromptCallbacks : PromptCallbacks
     {
         protected override IEnumerable<(KeyPressPattern Pattern, KeyPressCallbackAsync Callback)> GetKeyPressCallbacks()
         {
@@ -155,6 +156,7 @@ internal static class Program
                     return new CompletionItem(
                         replacementText: fruit.Name,
                         displayText: displayText,
+                        commitCharacterRules: new[] { new CharacterSetModificationRule(CharacterSetModificationKind.Add, new[] { ' ' }.ToImmutableArray()) }.ToImmutableArray(),
                         getExtendedDescription: _ => Task.FromResult(description)
                     );
                 })

--- a/src/PrettyPrompt/Console/IConsole.cs
+++ b/src/PrettyPrompt/Console/IConsole.cs
@@ -30,6 +30,11 @@ public interface IConsole
     void HideCursor();
     bool KeyAvailable { get; }
     ConsoleKeyInfo ReadKey(bool intercept);
+
+    /// <summary>
+    /// Enables ANSI escape codes for controlling the terminal.
+    /// https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences
+    /// </summary>
     void InitVirtualTerminalProcessing();
 
     event ConsoleCancelEventHandler CancelKeyPress;

--- a/src/PrettyPrompt/Console/SystemConsole.cs
+++ b/src/PrettyPrompt/Console/SystemConsole.cs
@@ -41,10 +41,6 @@ public class SystemConsole : IConsole
         remove => Console.CancelKeyPress -= value;
     }
 
-    /// <summary>
-    /// Enables ANSI escape codes for controlling the terminal.
-    /// https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences
-    /// </summary>
     public void InitVirtualTerminalProcessing()
     {
         if (!OperatingSystem.IsWindows()) return;

--- a/src/PrettyPrompt/PrettyPrompt.csproj
+++ b/src/PrettyPrompt/PrettyPrompt.csproj
@@ -40,5 +40,8 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>DynamicProxyGenAssembly2</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>PrettyPrompt.Benchmarks</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 </Project>

--- a/tests/PrettyPrompt.Benchmarks/PrettyPrompt.Benchmarks.csproj
+++ b/tests/PrettyPrompt.Benchmarks/PrettyPrompt.Benchmarks.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\examples\PrettyPrompt.Examples.FruitPrompt\PrettyPrompt.Examples.FruitPrompt.csproj" />
+    <ProjectReference Include="..\..\src\PrettyPrompt\PrettyPrompt.csproj" />
+    <ProjectReference Include="..\PrettyPrompt.Tests\PrettyPrompt.Tests.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/PrettyPrompt.Benchmarks/Program.cs
+++ b/tests/PrettyPrompt.Benchmarks/Program.cs
@@ -1,0 +1,133 @@
+﻿#region License Header
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+using PrettyPrompt;
+using PrettyPrompt.Consoles;
+using PrettyPrompt.Tests;
+
+using static System.ConsoleKey;
+using static System.ConsoleModifiers;
+
+public static class Program
+{
+    public static void Main()
+    {
+        BenchmarkRunner.Run<PromptBenchmark>();
+
+        //For manual running or debugging:
+        //var b = new PromptBenchmark();
+        //try
+        //{
+        //    b.Test().Wait();
+        //}
+        //finally
+        //{
+        //    b.GlobalCleanup();
+        //}
+    }
+}
+
+[MemoryDiagnoser]
+public class PromptBenchmark
+{
+    private const int PromptSubmits = 100;
+
+    private readonly BenchConsole console;
+    private readonly Prompt prompt;
+    private readonly string persistentHistoryFilepath;
+
+    public PromptBenchmark()
+    {
+        var inputs = new List<FormattableString>()
+        {
+            $"appl{Spacebar}ap{DownArrow}{DownArrow}{UpArrow}{Enter} avxyz{Backspace}{Backspace}{Backspace}oc{Enter}{Shift}{Enter}",
+            $"qwerty{Shift}{Home}{Delete}ban{Spacebar}cantaloupe grapef{Spacebar}gr{Enter} ma{DownArrow}{DownArrow}{UpArrow}{UpArrow}{Enter}{Shift}{Enter}",
+            $"{Shift}{Enter}{Shift}{Enter}{Shift}{Enter}",
+            $"me{Spacebar}o{Spacebar}pear peac{Enter}",
+            $"{Enter}", //submit
+        };
+
+        console = new BenchConsole(inputs);
+
+        persistentHistoryFilepath = Path.GetTempFileName();
+        prompt = new Prompt(
+            persistentHistoryFilepath,
+            callbacks: new PrettyPrompt.Program.FruitPromptCallbacks(),
+            console: console);
+    }
+
+    [IterationSetup]
+    public void IterationSetup() => console.Reset();
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        File.Delete(persistentHistoryFilepath);
+    }
+
+    [Benchmark]
+    public async Task Test()
+    {
+        for (int i = 0; i < PromptSubmits; i++)
+        {
+            //Console.WriteLine(i);
+
+            var result = await prompt.ReadLineAsync().ConfigureAwait(false);
+            Debug.Assert(result.Text ==
+                $"apple apricot avocado{Environment.NewLine}" +
+                $"banana cantaloupe grapefruit grape mango{Environment.NewLine}" +
+                $"{Environment.NewLine}{Environment.NewLine}{Environment.NewLine}" +
+                $"melon orange pear peach");
+        }
+    }
+
+    //don't use NSubstite as in unit tests because it's slow
+    private class BenchConsole : IConsole
+    {
+        private readonly ConsoleKeyInfo[] keys;
+        private int keyIndex;
+
+        public BenchConsole(List<FormattableString> inputs)
+        {
+            keys = inputs.SelectMany(i => ConsoleStub.MapToConsoleKeyPresses(i)).ToArray();
+        }
+
+        ConsoleKeyInfo IConsole.ReadKey(bool intercept)
+        {
+            var result = keys[keyIndex];
+            keyIndex = (keyIndex + 1) % keys.Length;
+            return result;
+        }
+
+        public void Reset() => keyIndex = 0;
+
+        int IConsole.CursorTop => 0;
+        int IConsole.BufferWidth => 240;
+        int IConsole.WindowHeight => 80;
+        int IConsole.WindowTop => 0;
+        bool IConsole.KeyAvailable => false;
+        bool IConsole.CaptureControlC { get => false; set { } }
+
+        event ConsoleCancelEventHandler IConsole.CancelKeyPress { add { } remove { } }
+
+        void IConsole.Clear() { }
+        void IConsole.HideCursor() { }
+        void IConsole.InitVirtualTerminalProcessing() { }
+        void IConsole.ShowCursor() { }
+        void IConsole.Write(string? value) { }
+        void IConsole.WriteError(string? value) { }
+        void IConsole.WriteErrorLine(string? value) { }
+        void IConsole.WriteLine(string? value) { }
+    }
+}

--- a/tests/PrettyPrompt.Tests/ConsoleStub.cs
+++ b/tests/PrettyPrompt.Tests/ConsoleStub.cs
@@ -122,7 +122,7 @@ internal static class ConsoleStub
             .Returns(keys.First(), keys.Skip(1).ToArray());
     }
 
-    private static List<ConsoleKeyInfo> MapToConsoleKeyPresses(FormattableString input)
+    internal static List<ConsoleKeyInfo> MapToConsoleKeyPresses(FormattableString input)
     {
         ConsoleModifiers modifiersPressed = 0;
         // split the formattable strings into a mix of format placeholders (e.g. {0}, {1}) and literal characters.

--- a/tests/PrettyPrompt.Tests/PrettyPrompt.Tests.csproj
+++ b/tests/PrettyPrompt.Tests/PrettyPrompt.Tests.csproj
@@ -31,4 +31,9 @@
     <None Remove="TestResults\**" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>PrettyPrompt.Benchmarks</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Uses FruitApp completions and test 100x submit of following input:
`
$"appl{Spacebar}ap{DownArrow}{DownArrow}{UpArrow}{Enter} avxyz{Backspace}{Backspace}{Backspace}oc{Enter}{Shift}{Enter}",
$"qwerty{Shift}{Home}{Delete}ban{Spacebar}cantaloupe grapef{Spacebar}gr{Enter} ma{DownArrow}{DownArrow}{UpArrow}{UpArrow}{Enter}{Shift}{Enter}",
$"{Shift}{Enter}{Shift}{Enter}{Shift}{Enter}",
$"me{Spacebar}o{Spacebar}pear peac{Enter}",
$"{Enter}"
`

For measurements it uses https://benchmarkdotnet.org/.

It's enough to run the project in Release without debugger:
![image](https://user-images.githubusercontent.com/11704036/174879051-d8fe2e78-26f7-469e-a0a4-c14f4f7baa0b.png)