### PR TITLE
Renderer simplification + perf improvements

### DIFF
--- a/src/PrettyPrompt/Extensions.cs
+++ b/src/PrettyPrompt/Extensions.cs
@@ -5,7 +5,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 using PrettyPrompt.Documents;
@@ -60,7 +59,7 @@ public static class Extensions
     public static ReadOnlySpan<char> AsSpan(this string text, TextSpan span)
         => text.AsSpan(span.Start, span.Length);
 
-    internal static void TransformBackground(this Cell cell, AnsiColor? background)
+    internal static void TransformBackground(this Cell cell, in AnsiColor? background)
     {
         if (cell.Formatting.Background is null)
         {
@@ -68,11 +67,16 @@ public static class Extensions
         }
     }
 
-    internal static void TransformBackground(this Row row, AnsiColor? background, int startIndex = 0)
+    internal static void TransformBackground(this Row row, in AnsiColor? background, int startIndex = 0)
+        => TransformBackground(row, background, startIndex, count: row.Length - startIndex);
+
+    internal static void TransformBackground(this Row row, in AnsiColor? background, int startIndex, int count)
     {
         Debug.Assert(startIndex >= 0);
         Debug.Assert(startIndex <= row.Length);
-        for (int i = startIndex; i < row.Length; i++)
+        Debug.Assert(count >= 0);
+        Debug.Assert(startIndex + count <= row.Length);
+        for (int i = startIndex; i < startIndex + count; i++)
         {
             row[i].TransformBackground(background);
         }

--- a/src/PrettyPrompt/Highlighting/FormattedString.cs
+++ b/src/PrettyPrompt/Highlighting/FormattedString.cs
@@ -39,6 +39,12 @@ public readonly struct FormattedString : IEquatable<FormattedString>
         : this(text, formatSpans?.ToArray())
     { }
 
+    public FormattedString(string? text)
+    {
+        Text = text;
+        formatSpans = Array.Empty<FormatSpan>();
+    }
+
     public FormattedString(string? text, params FormatSpan[]? formatSpans)
     {
         Text = text;
@@ -83,7 +89,7 @@ public readonly struct FormattedString : IEquatable<FormattedString>
         }
     }
 
-    public FormattedString(string? text, ConsoleFormat formatting)
+    public FormattedString(string? text, in ConsoleFormat formatting)
         : this(text, (text?.Length ?? 0) == 0 ? Array.Empty<FormatSpan>() : new[] { new FormatSpan(0, text!.Length, formatting) })
     {
     }

--- a/src/PrettyPrompt/PromptConfiguration.cs
+++ b/src/PrettyPrompt/PromptConfiguration.cs
@@ -24,7 +24,9 @@ public class PromptConfiguration
     /// </summary>
     public FormattedString Prompt { get; }
 
-    public ConsoleFormat CompletionBoxBorderFormat { get; }
+    private readonly ConsoleFormat completionBoxBorderFormat;
+    public ref readonly ConsoleFormat CompletionBoxBorderFormat => ref completionBoxBorderFormat;
+
     public AnsiColor? CompletionItemDescriptionPaneBackground { get; }
     public FormattedString SelectedCompletionItemMarker { get; }
     public string UnselectedCompletionItemMarker { get; }
@@ -66,7 +68,7 @@ public class PromptConfiguration
         KeyBindings = keyBindings ?? new KeyBindings();
         Prompt = prompt ?? "> ";
 
-        CompletionBoxBorderFormat = GetFormat(completionBoxBorderFormat ?? new ConsoleFormat(Foreground: AnsiColor.Blue));
+        this.completionBoxBorderFormat = GetFormat(completionBoxBorderFormat ?? new ConsoleFormat(Foreground: AnsiColor.Blue));
         CompletionItemDescriptionPaneBackground = GetColor(completionItemDescriptionPaneBackground);
 
         SelectedCompletionItemMarker = selectedCompletionItemMarkSymbol ?? new FormattedString(">", new FormatSpan(0, 1, AnsiColor.Cyan));

--- a/src/PrettyPrompt/Rendering/BoxDrawing.cs
+++ b/src/PrettyPrompt/Rendering/BoxDrawing.cs
@@ -217,4 +217,42 @@ internal class BoxDrawing
             row.Add(EdgeVerticalCell);
         }
     }
+
+    public void Connect(Row[] completionBox, Row[] documentationBox)
+    {
+        if (completionBox.Length == 0 || documentationBox.Length == 0) return;
+
+        documentationBox[0].Replace(0, EdgeHorizontalAndLowerVerticalCell); // ┬
+        if (completionBox.Length == documentationBox.Length)
+        {
+            //  ┌──────────────┬─────────────────────────────┐
+            //  │ completion 1 │ documentation box with some |
+            //  │ completion 2 │ docs that may wrap.         |
+            //  │ completion 3 │ ............                │
+            //  └──────────────┴─────────────────────────────┘
+
+            documentationBox[^1].Replace(0, EdgeHorizontalAndUpperVerticalCell); // ┴
+        }
+        else if (completionBox.Length > documentationBox.Length)
+        {
+            //  ┌──────────────┬─────────────────────────────┐
+            //  │ completion 1 │ documentation box with some |
+            //  │ completion 2 │ docs that may wrap.         |
+            //  │ completion 3 ├─────────────────────────────┘
+            //  └──────────────┘
+
+            documentationBox[^1].Replace(0, EdgeVerticalAndRightHorizontalCell); // ├
+        }
+        else
+        {
+            //  ┌──────────────┬─────────────────────────────┐
+            //  │ completion 1 │ documentation box with some │
+            //  │ completion 2 │ docs that may wrap.         │
+            //  │ completion 3 │ .............               │
+            //  └──────────────┤ .............               │
+            //                 └─────────────────────────────┘
+
+            documentationBox[completionBox.Length - 1].Replace(0, EdgeVerticalAndLeftHorizontalCell); // ┤
+        }
+    }
 }

--- a/src/PrettyPrompt/Rendering/BoxDrawing.cs
+++ b/src/PrettyPrompt/Rendering/BoxDrawing.cs
@@ -4,6 +4,13 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #endregion
 
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using PrettyPrompt.Consoles;
+using PrettyPrompt.Highlighting;
+
 namespace PrettyPrompt.Rendering;
 
 internal static class BoxDrawing
@@ -23,16 +30,167 @@ internal static class BoxDrawing
     public const char EdgeHorizontalAndLowerVertical = '┬';
     public const char EdgeHorizontalAndUpperVertical = '┴';
 
+    private const string CornerUpperRightText = "┐";
+    private const string CornerLowerRightText = "┘";
+    private const string CornerUpperLeftText = "┌";
+    private const string CornerLowerLeftText = "└";
+    private const string EdgeHorizontalText = "─";
+    private const string EdgeVerticalText = "│";
+    //private const string EdgeVerticalAndLeftHorizontalText = "┤";
+    //private const string EdgeVerticalAndRightHorizontalText = "├";
+    //private const string EdgeHorizontalAndLowerVerticalText = "┬";
+    //private const string EdgeHorizontalAndUpperVerticalText = "┴";
+
     public const int MinUsedCharacterValue = EdgeHorizontal;
     public const int MaxUsedCharacterValue = EdgeHorizontalAndUpperVertical;
 
-    public static (string top, string bottom) HorizontalBorders(int width, bool leftCorner = true, bool rightCorner = true)
+    public static Row[] BuildFromItemList(
+        IEnumerable<FormattedString> items,
+        PromptConfiguration configuration,
+        int maxWidth,
+        int? selectedLineIndex = null)
     {
-        var boxHorizontalBorder = new string(EdgeHorizontal, width); // -1 to make up for right corner piece
+        return BuildInternal(
+            items,
+            configuration,
+            maxWidth,
+            selectedLineIndex,
+            configuration.SelectedCompletionItemMarker,
+            configuration.UnselectedCompletionItemMarker,
+            background: null);
+    }
 
-        return (
-            top: (leftCorner ? CornerUpperLeft : "") + boxHorizontalBorder + (rightCorner ? CornerUpperRight : ""),
-            bottom: (leftCorner ? CornerLowerLeft : "") + boxHorizontalBorder + (rightCorner ? CornerLowerRight : "")
-        );
+    public static Row[] BuildFromLines(
+        IEnumerable<FormattedString> lines,
+        PromptConfiguration configuration,
+        in AnsiColor? background)
+    {
+        return BuildInternal(
+            lines,
+            configuration,
+            maxWidth: int.MaxValue,
+            selectedLineIndex: null,
+            selectedLineMarker: " ",
+            unselectedLineMarker: " ",
+            background);
+    }
+
+    private static Row[] BuildInternal(
+        IEnumerable<FormattedString> lines,
+        PromptConfiguration configuration,
+        int maxWidth,
+        int? selectedLineIndex,
+        FormattedString selectedLineMarker,
+        string unselectedLineMarker,
+        in AnsiColor? background)
+    {
+        const string Padding = " ";
+        int lineMarkerWidth = UnicodeWidth.GetWidth(unselectedLineMarker);
+        var leftPaddingWidth = selectedLineIndex.HasValue ? lineMarkerWidth : Padding.Length;
+        if (maxWidth </*leftBorder*/EdgeVerticalText.Length + leftPaddingWidth + /*rightPadding*/Padding.Length + /*leftBorder*/EdgeVerticalText.Length)
+        {
+            return Array.Empty<Row>();
+        }
+
+        if (!lines.TryGetNonEnumeratedCount(out var capacity)) capacity = 16;
+
+        var lineList = ListPool<FormattedString>.Shared.Get(capacity);
+        int maxLineWidth = 0;
+        foreach (var line in lines)
+        {
+            lineList.Add(line);
+            var lineWidth = line.GetUnicodeWidth();
+            if (lineWidth > maxLineWidth) maxLineWidth = lineWidth;
+        }
+
+        var boxWidth = Math.Min(
+            /*leftBorder*/EdgeVerticalText.Length + leftPaddingWidth + maxLineWidth + /*rightPadding*/Padding.Length + /*rightBorder*/EdgeVerticalText.Length,
+            maxWidth);
+
+        var rows = ListPool<Row>.Shared.Get(lineList.Count);
+        ref readonly var completionBoxBorderFormat = ref configuration.CompletionBoxBorderFormat;
+
+        //Top border.
+        var row = new Row(boxWidth);
+        row.Add(CornerUpperLeftText, completionBoxBorderFormat);
+        for (int i = CornerUpperLeftText.Length + CornerUpperRightText.Length; i < boxWidth; i++) row.Add(EdgeHorizontalText, completionBoxBorderFormat);
+        row.Add(CornerUpperRightText, completionBoxBorderFormat);
+        rows.Add(row);
+
+        //Lines.
+        var lineAvailableWidth = boxWidth -/*leftBorder*/EdgeVerticalText.Length - leftPaddingWidth - /*rightPadding*/Padding.Length - /*rightBorder*/EdgeVerticalText.Length;
+        for (int i = 0; i < lineList.Count; i++)
+        {
+            row = new Row(boxWidth);
+            var line = lineList[i];
+            FillLineRow(row, line.Substring(0, Math.Min(line.Length, lineAvailableWidth)), i, completionBoxBorderFormat, background);
+            rows.Add(row);
+        }
+
+        //Bottom border.
+        row = new Row(boxWidth);
+        row.Add(CornerLowerLeftText, completionBoxBorderFormat);
+        for (int i = CornerUpperLeftText.Length + CornerUpperRightText.Length; i < boxWidth; i++) row.Add(EdgeHorizontalText, completionBoxBorderFormat);
+        row.Add(CornerLowerRightText, completionBoxBorderFormat);
+        rows.Add(row);
+
+        var result = rows.ToArray();
+        ListPool<Row>.Shared.Put(rows);
+        ListPool<FormattedString>.Shared.Put(lineList);
+        return result;
+
+        void FillLineRow(Row row, FormattedString line, int lineIndex, in ConsoleFormat completionBoxBorderFormat, in AnsiColor? background)
+        {
+            //Left border.
+            row.Add(EdgeVerticalText, completionBoxBorderFormat);
+
+            //Left padding.
+            bool isSelected = false;
+            if (selectedLineIndex.TryGet(out var selectedLineIndexValue))
+            {
+                if (selectedLineIndexValue == lineIndex)
+                {
+                    isSelected = true;
+                    row.Add(selectedLineMarker);
+                }
+                else
+                {
+                    row.Add(unselectedLineMarker);
+                }
+            }
+            else
+            {
+                row.Add(Padding);
+            }
+
+            //Line.
+            row.Add(line);
+
+            //Right padding.
+            var rightPaddingWidth = maxLineWidth - line.GetUnicodeWidth() + 1;
+            for (int i = 0; i < rightPaddingWidth; i++)
+            {
+                row.Add(Padding);
+            }
+
+            if (background != null)
+            {
+                row.TransformBackground(
+                    background,
+                    startIndex: EdgeVerticalText.Length + lineMarkerWidth,
+                    count: row.Length - EdgeVerticalText.Length - lineMarkerWidth - 1);
+            }
+
+            if (isSelected)
+            {
+                row.TransformBackground(
+                    configuration.SelectedCompletionItemBackground,
+                    startIndex: EdgeVerticalText.Length + lineMarkerWidth,
+                    count: row.Length - EdgeVerticalText.Length - lineMarkerWidth - 1);
+            }
+
+            //Right border.
+            row.Add(EdgeVerticalText, completionBoxBorderFormat);
+        }
     }
 }

--- a/src/PrettyPrompt/Rendering/BoxDrawing.cs
+++ b/src/PrettyPrompt/Rendering/BoxDrawing.cs
@@ -13,35 +13,6 @@ namespace PrettyPrompt.Rendering;
 
 internal class BoxDrawing
 {
-    //
-    // ATTENTION: When changing collection of following characters don't forget to update MinUsedCharacterValue/MaxUsedCharacterValue constants.
-    //            Also make sure their difference is sufficiently small because we allocate cache of that size.
-    //
-    public const char CornerUpperRight = '┐';
-    public const char CornerLowerRight = '┘';
-    public const char CornerUpperLeft = '┌';
-    public const char CornerLowerLeft = '└';
-    public const char EdgeHorizontal = '─';
-    public const char EdgeVertical = '│';
-    public const char EdgeVerticalAndLeftHorizontal = '┤';
-    public const char EdgeVerticalAndRightHorizontal = '├';
-    public const char EdgeHorizontalAndLowerVertical = '┬';
-    public const char EdgeHorizontalAndUpperVertical = '┴';
-
-    private const string CornerUpperRightText = "┐";
-    //private const string CornerLowerRightText = "┘";
-    private const string CornerUpperLeftText = "┌";
-    //private const string CornerLowerLeftText = "└";
-    //private const string EdgeHorizontalText = "─";
-    private const string EdgeVerticalText = "│";
-    //private const string EdgeVerticalAndLeftHorizontalText = "┤";
-    //private const string EdgeVerticalAndRightHorizontalText = "├";
-    //private const string EdgeHorizontalAndLowerVerticalText = "┬";
-    //private const string EdgeHorizontalAndUpperVerticalText = "┴";
-
-    public const int MinUsedCharacterValue = EdgeHorizontal;
-    public const int MaxUsedCharacterValue = EdgeHorizontalAndUpperVertical;
-
     private readonly Cell CornerUpperRightCell;
     private readonly Cell CornerLowerRightCell;
     private readonly Cell CornerUpperLeftCell;
@@ -112,7 +83,7 @@ internal class BoxDrawing
         const string Padding = " ";
         int lineMarkerWidth = UnicodeWidth.GetWidth(unselectedLineMarker);
         var leftPaddingWidth = selectedLineIndex.HasValue ? lineMarkerWidth : Padding.Length;
-        if (maxWidth </*leftBorder*/EdgeVerticalText.Length + leftPaddingWidth + /*rightPadding*/Padding.Length + /*leftBorder*/EdgeVerticalText.Length)
+        if (maxWidth </*leftBorder*/1 + leftPaddingWidth + /*rightPadding*/Padding.Length + /*leftBorder*/1)
         {
             return Array.Empty<Row>();
         }
@@ -129,7 +100,7 @@ internal class BoxDrawing
         }
 
         var boxWidth = Math.Min(
-            /*leftBorder*/EdgeVerticalText.Length + leftPaddingWidth + maxLineWidth + /*rightPadding*/Padding.Length + /*rightBorder*/EdgeVerticalText.Length,
+            /*leftBorder*/1 + leftPaddingWidth + maxLineWidth + /*rightPadding*/Padding.Length + /*rightBorder*/1,
             maxWidth);
 
         var rows = ListPool<Row>.Shared.Get(lineList.Count);
@@ -137,12 +108,12 @@ internal class BoxDrawing
         //Top border.
         var row = new Row(boxWidth);
         row.Add(CornerUpperLeftCell);
-        for (int i = CornerUpperLeftText.Length + CornerUpperRightText.Length; i < boxWidth; i++) row.Add(EdgeHorizontalCell);
+        for (int i = /*leftCorner*/1 + /*rightBorder*/1; i < boxWidth; i++) row.Add(EdgeHorizontalCell);
         row.Add(CornerUpperRightCell);
         rows.Add(row);
 
         //Lines.
-        var lineAvailableWidth = boxWidth -/*leftBorder*/EdgeVerticalText.Length - leftPaddingWidth - /*rightPadding*/Padding.Length - /*rightBorder*/EdgeVerticalText.Length;
+        var lineAvailableWidth = boxWidth -/*leftBorder*/1 - leftPaddingWidth - /*rightPadding*/Padding.Length - /*rightBorder*/1;
         for (int i = 0; i < lineList.Count; i++)
         {
             row = new Row(boxWidth);
@@ -154,7 +125,7 @@ internal class BoxDrawing
         //Bottom border.
         row = new Row(boxWidth);
         row.Add(CornerLowerLeftCell);
-        for (int i = CornerUpperLeftText.Length + CornerUpperRightText.Length; i < boxWidth; i++) row.Add(EdgeHorizontalCell);
+        for (int i = /*leftCorner*/1 + /*rightBorder*/1; i < boxWidth; i++) row.Add(EdgeHorizontalCell);
         row.Add(CornerLowerRightCell);
         rows.Add(row);
 
@@ -201,16 +172,16 @@ internal class BoxDrawing
             {
                 row.TransformBackground(
                     background,
-                    startIndex: EdgeVerticalText.Length + lineMarkerWidth,
-                    count: row.Length - EdgeVerticalText.Length - lineMarkerWidth - 1);
+                    startIndex: /*border*/1 + lineMarkerWidth,
+                    count: row.Length - /*border*/1 - lineMarkerWidth - 1);
             }
 
             if (isSelected)
             {
                 row.TransformBackground(
                     configuration.SelectedCompletionItemBackground,
-                    startIndex: EdgeVerticalText.Length + lineMarkerWidth,
-                    count: row.Length - EdgeVerticalText.Length - lineMarkerWidth - 1);
+                    startIndex: /*border*/1 + lineMarkerWidth,
+                    count: row.Length - /*border*/1 - lineMarkerWidth - 1);
             }
 
             //Right border.

--- a/src/PrettyPrompt/Rendering/BoxDrawing.cs
+++ b/src/PrettyPrompt/Rendering/BoxDrawing.cs
@@ -6,14 +6,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using PrettyPrompt.Consoles;
 using PrettyPrompt.Highlighting;
 
 namespace PrettyPrompt.Rendering;
 
-internal static class BoxDrawing
+internal class BoxDrawing
 {
     //
     // ATTENTION: When changing collection of following characters don't forget to update MinUsedCharacterValue/MaxUsedCharacterValue constants.
@@ -31,10 +29,10 @@ internal static class BoxDrawing
     public const char EdgeHorizontalAndUpperVertical = '┴';
 
     private const string CornerUpperRightText = "┐";
-    private const string CornerLowerRightText = "┘";
+    //private const string CornerLowerRightText = "┘";
     private const string CornerUpperLeftText = "┌";
-    private const string CornerLowerLeftText = "└";
-    private const string EdgeHorizontalText = "─";
+    //private const string CornerLowerLeftText = "└";
+    //private const string EdgeHorizontalText = "─";
     private const string EdgeVerticalText = "│";
     //private const string EdgeVerticalAndLeftHorizontalText = "┤";
     //private const string EdgeVerticalAndRightHorizontalText = "├";
@@ -44,7 +42,34 @@ internal static class BoxDrawing
     public const int MinUsedCharacterValue = EdgeHorizontal;
     public const int MaxUsedCharacterValue = EdgeHorizontalAndUpperVertical;
 
-    public static Row[] BuildFromItemList(
+    private readonly Cell CornerUpperRightCell;
+    private readonly Cell CornerLowerRightCell;
+    private readonly Cell CornerUpperLeftCell;
+    private readonly Cell CornerLowerLeftCell;
+    private readonly Cell EdgeHorizontalCell;
+    private readonly Cell EdgeVerticalCell;
+    private readonly Cell EdgeVerticalAndLeftHorizontalCell;
+    private readonly Cell EdgeVerticalAndRightHorizontalCell;
+    private readonly Cell EdgeHorizontalAndLowerVerticalCell;
+    private readonly Cell EdgeHorizontalAndUpperVerticalCell;
+
+    public BoxDrawing(PromptConfiguration configuration)
+    {
+        ref readonly var format = ref configuration.CompletionBoxBorderFormat;
+        CornerUpperRightCell = Cell.CreateSingleNonpoolableCell('┐', format);
+        CornerLowerRightCell = Cell.CreateSingleNonpoolableCell('┘', format);
+        CornerUpperLeftCell = Cell.CreateSingleNonpoolableCell('┌', format);
+        CornerLowerLeftCell = Cell.CreateSingleNonpoolableCell('└', format);
+        EdgeHorizontalCell = Cell.CreateSingleNonpoolableCell('─', format);
+        EdgeVerticalCell = Cell.CreateSingleNonpoolableCell('│', format);
+        EdgeVerticalAndLeftHorizontalCell = Cell.CreateSingleNonpoolableCell('┤', format);
+        EdgeVerticalAndRightHorizontalCell = Cell.CreateSingleNonpoolableCell('├', format);
+        EdgeHorizontalAndLowerVerticalCell = Cell.CreateSingleNonpoolableCell('┬', format);
+        EdgeHorizontalAndUpperVerticalCell = Cell.CreateSingleNonpoolableCell('┴', format);
+
+    }
+
+    public Row[] BuildFromItemList(
         IEnumerable<FormattedString> items,
         PromptConfiguration configuration,
         int maxWidth,
@@ -60,7 +85,7 @@ internal static class BoxDrawing
             background: null);
     }
 
-    public static Row[] BuildFromLines(
+    public Row[] BuildFromLines(
         IEnumerable<FormattedString> lines,
         PromptConfiguration configuration,
         in AnsiColor? background)
@@ -75,7 +100,7 @@ internal static class BoxDrawing
             background);
     }
 
-    private static Row[] BuildInternal(
+    private Row[] BuildInternal(
         IEnumerable<FormattedString> lines,
         PromptConfiguration configuration,
         int maxWidth,
@@ -108,13 +133,12 @@ internal static class BoxDrawing
             maxWidth);
 
         var rows = ListPool<Row>.Shared.Get(lineList.Count);
-        ref readonly var completionBoxBorderFormat = ref configuration.CompletionBoxBorderFormat;
 
         //Top border.
         var row = new Row(boxWidth);
-        row.Add(CornerUpperLeftText, completionBoxBorderFormat);
-        for (int i = CornerUpperLeftText.Length + CornerUpperRightText.Length; i < boxWidth; i++) row.Add(EdgeHorizontalText, completionBoxBorderFormat);
-        row.Add(CornerUpperRightText, completionBoxBorderFormat);
+        row.Add(CornerUpperLeftCell);
+        for (int i = CornerUpperLeftText.Length + CornerUpperRightText.Length; i < boxWidth; i++) row.Add(EdgeHorizontalCell);
+        row.Add(CornerUpperRightCell);
         rows.Add(row);
 
         //Lines.
@@ -123,15 +147,15 @@ internal static class BoxDrawing
         {
             row = new Row(boxWidth);
             var line = lineList[i];
-            FillLineRow(row, line.Substring(0, Math.Min(line.Length, lineAvailableWidth)), i, completionBoxBorderFormat, background);
+            FillLineRow(row, line.Substring(0, Math.Min(line.Length, lineAvailableWidth)), i, background);
             rows.Add(row);
         }
 
         //Bottom border.
         row = new Row(boxWidth);
-        row.Add(CornerLowerLeftText, completionBoxBorderFormat);
-        for (int i = CornerUpperLeftText.Length + CornerUpperRightText.Length; i < boxWidth; i++) row.Add(EdgeHorizontalText, completionBoxBorderFormat);
-        row.Add(CornerLowerRightText, completionBoxBorderFormat);
+        row.Add(CornerLowerLeftCell);
+        for (int i = CornerUpperLeftText.Length + CornerUpperRightText.Length; i < boxWidth; i++) row.Add(EdgeHorizontalCell);
+        row.Add(CornerLowerRightCell);
         rows.Add(row);
 
         var result = rows.ToArray();
@@ -139,10 +163,10 @@ internal static class BoxDrawing
         ListPool<FormattedString>.Shared.Put(lineList);
         return result;
 
-        void FillLineRow(Row row, FormattedString line, int lineIndex, in ConsoleFormat completionBoxBorderFormat, in AnsiColor? background)
+        void FillLineRow(Row row, FormattedString line, int lineIndex, in AnsiColor? background)
         {
             //Left border.
-            row.Add(EdgeVerticalText, completionBoxBorderFormat);
+            row.Add(EdgeVerticalCell);
 
             //Left padding.
             bool isSelected = false;
@@ -190,7 +214,7 @@ internal static class BoxDrawing
             }
 
             //Right border.
-            row.Add(EdgeVerticalText, completionBoxBorderFormat);
+            row.Add(EdgeVerticalCell);
         }
     }
 }

--- a/src/PrettyPrompt/Rendering/Renderer.cs
+++ b/src/PrettyPrompt/Rendering/Renderer.cs
@@ -192,44 +192,11 @@ internal class Renderer : IDisposable
             completionRowsCount: completionRows.Length
         );
 
+        boxDrawing.Connect(completionRows, documentationRows);
+
         var completionArea = new ScreenArea(completionStart, completionRows);
         var documentationArea = new ScreenArea(documentationStart, documentationRows);
-        var connectionHeight = Math.Max(0, documentationRows.Length - completionRows.Length);
-        var completionTopRightCorner = new ConsoleCoordinate(completionStart.Row, completionStart.Column + boxWidth - 1);
-        if (connectionHeight > 0)
-        {
-            var connectionRow = new Row(BoxDrawing.EdgeVertical.ToString(), configuration.CompletionBoxBorderFormat);
-            var connectionRows = Enumerable.Repeat(connectionRow, connectionHeight - 1)
-                .Prepend(new Row(BoxDrawing.EdgeVerticalAndLeftHorizontal.ToString(), configuration.CompletionBoxBorderFormat))
-                .Append(new Row(BoxDrawing.CornerLowerLeft.ToString(), configuration.CompletionBoxBorderFormat))
-                .ToArray();
-
-            var completionBottomRightCorner = new ConsoleCoordinate(completionStart.Row + completionRows.Length - 1, completionStart.Column + boxWidth - 1);
-            var connectionArea = new ScreenArea(completionBottomRightCorner, connectionRows);
-
-            var topRightCornerRow = new Row(BoxDrawing.EdgeHorizontalAndLowerVertical.ToString(), configuration.CompletionBoxBorderFormat);
-            var topRightCornerArea = new ScreenArea(completionTopRightCorner, new[] { topRightCornerRow });
-
-            return new[] { completionArea, documentationArea, topRightCornerArea, connectionArea };
-        }
-        else
-        {
-            if (documentationRows.Length > 0)
-            {
-                var topRightCornerRow = new Row(BoxDrawing.EdgeHorizontalAndLowerVertical.ToString(), configuration.CompletionBoxBorderFormat);
-                var topRightCornerArea = new ScreenArea(completionTopRightCorner, new[] { topRightCornerRow });
-
-                var lowerConnectionCorner = new ConsoleCoordinate(completionStart.Row + documentationRows.Length - 1, completionStart.Column + boxWidth - 1);
-                var bottomRightCornerRow = new Row(documentationRows.Length < completionRows.Length ? BoxDrawing.EdgeVerticalAndRightHorizontal.ToString() : BoxDrawing.EdgeHorizontalAndUpperVertical.ToString(), configuration.CompletionBoxBorderFormat);
-                var bottomRightCornerArea = new ScreenArea(lowerConnectionCorner, new[] { bottomRightCornerRow });
-
-                return new[] { completionArea, documentationArea, topRightCornerArea, bottomRightCornerArea };
-            }
-            else
-            {
-                return new[] { completionArea, documentationArea, };
-            }
-        }
+        return new[] { completionArea, documentationArea };
     }
 
     private Row[] BuildCompletionRows(CompletionPane completionPane, int codeAreaWidth, ConsoleCoordinate completionBoxStart)

--- a/src/PrettyPrompt/Rendering/Renderer.cs
+++ b/src/PrettyPrompt/Rendering/Renderer.cs
@@ -29,6 +29,7 @@ namespace PrettyPrompt;
 internal class Renderer : IDisposable
 {
     private readonly IConsole console;
+    private readonly BoxDrawing boxDrawing;
     private readonly PromptConfiguration configuration;
 
     private Screen previouslyRenderedScreen = new(0, 0, ConsoleCoordinate.Zero);
@@ -37,6 +38,7 @@ internal class Renderer : IDisposable
     public Renderer(IConsole console, PromptConfiguration configuration)
     {
         this.console = console;
+        this.boxDrawing = new BoxDrawing(configuration);
         this.configuration = configuration;
     }
 
@@ -232,7 +234,7 @@ internal class Renderer : IDisposable
 
     private Row[] BuildCompletionRows(CompletionPane completionPane, int codeAreaWidth, ConsoleCoordinate completionBoxStart)
     {
-        return BoxDrawing.BuildFromItemList(
+        return boxDrawing.BuildFromItemList(
             items: completionPane.FilteredView.VisibleItems.Select(c => c.DisplayTextFormatted),
             configuration: configuration,
             maxWidth: codeAreaWidth - completionBoxStart.Column,
@@ -274,7 +276,7 @@ internal class Renderer : IDisposable
 
         Debug.Assert(documentationLines != null);
 
-        return BoxDrawing.BuildFromLines(
+        return boxDrawing.BuildFromLines(
             lines: documentationLines,
             configuration: configuration,
             background: configuration.CompletionItemDescriptionPaneBackground);

--- a/src/PrettyPrompt/Rendering/Row.cs
+++ b/src/PrettyPrompt/Rendering/Row.cs
@@ -69,6 +69,12 @@ internal class Row : IDisposable
     public void Add(Cell cell)
         => cells.Add(cell);
 
+    public void Replace(int index, Cell cell)
+    {
+        Cell.SharedPool.Put(cells[index]);
+        cells[index] = cell;
+    }
+
     public void CopyTo(Cell?[] cells, int targetPosition, int count)
         => this.cells.CopyTo(0, cells!, targetPosition, count);
 

--- a/src/PrettyPrompt/Rendering/Row.cs
+++ b/src/PrettyPrompt/Rendering/Row.cs
@@ -66,6 +66,9 @@ internal class Row : IDisposable
     public void Add(FormattedString formattedString)
         => Cell.AddTo(cells, formattedString);
 
+    public void Add(Cell cell)
+        => cells.Add(cell);
+
     public void CopyTo(Cell?[] cells, int targetPosition, int count)
         => this.cells.CopyTo(0, cells!, targetPosition, count);
 

--- a/src/PrettyPrompt/Rendering/Row.cs
+++ b/src/PrettyPrompt/Rendering/Row.cs
@@ -57,13 +57,10 @@ internal class Row : IDisposable
         }
     }
 
-    public void Add(char text, ConsoleFormat formatting)
-        => Add(new FormattedString(text.ToString(), formatting));
-
     public void Add(string text)
-        => Add(text, ConsoleFormat.None);
+        => Add(new FormattedString(text));
 
-    public void Add(string text, ConsoleFormat formatting)
+    public void Add(string text, in ConsoleFormat formatting)
         => Add(new FormattedString(text, formatting));
 
     public void Add(FormattedString formattedString)

--- a/src/PrettyPrompt/StringCache.cs
+++ b/src/PrettyPrompt/StringCache.cs
@@ -13,7 +13,6 @@ namespace PrettyPrompt;
 internal sealed class StringCache
 {
     private readonly (string Text, byte UnicodeWidth)[] asciiCache = new (string, byte)[256];
-    private readonly string[] boxDrawingCache = new string[BoxDrawing.MaxUsedCharacterValue - BoxDrawing.MinUsedCharacterValue + 1];
 
     public static readonly StringCache Shared = new();
 
@@ -23,13 +22,6 @@ internal sealed class StringCache
         {
             var c = (char)i;
             asciiCache[i] = (c.ToString(), checked((byte)UnicodeWidth.GetWidth(c)));
-        }
-
-        for (int i = 0; i < boxDrawingCache.Length; i++)
-        {
-            var c = (char)(BoxDrawing.MinUsedCharacterValue + i);
-            boxDrawingCache[i] = c.ToString();
-            Debug.Assert(UnicodeWidth.GetWidth(c) == 1);
         }
     }
 
@@ -43,19 +35,10 @@ internal sealed class StringCache
         }
         else
         {
-            idx -= BoxDrawing.MinUsedCharacterValue;
-            if ((uint)idx < (uint)boxDrawingCache.Length)
-            {
-                unicodeWidth = 1;
-                return boxDrawingCache[idx];
-            }
-            else
-            {
-                var result = character.ToString();
-                Debug.Assert(result.Length == 1);
-                unicodeWidth = UnicodeWidth.GetWidth(character);
-                return result;
-            }
+            var result = character.ToString();
+            Debug.Assert(result.Length == 1);
+            unicodeWidth = UnicodeWidth.GetWidth(character);
+            return result;
         }
     }
 


### PR DESCRIPTION
Box rendering and box connecting are refactored out of `Renderer` to `BoxDrawing`. This simplifies `Renderer` code and improves its performance.

Before #205:
![image](https://user-images.githubusercontent.com/11704036/177991946-820753fa-62ab-4073-a276-75da24390a8a.png)

Before this PR (=after #205):
![image](https://user-images.githubusercontent.com/11704036/177991765-33f6dd46-00cf-4dea-a398-2e29c8024e7d.png)

Now:
![image](https://user-images.githubusercontent.com/11704036/177991566-40214e7a-2fe4-4aa3-bb23-a9c2508a105b.png)
