### PR TITLE
Set up nuget publishing via GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
         $localversion = $csproj.Project.PropertyGroup.Version[0]
         $publishedversions = (Invoke-RestMethod https://api.nuget.org/v3-flatcontainer/PrettyPrompt/index.json).versions
         $isReleaseRequired = (-not $publishedversions.Contains($localversion)).ToString().ToLower()
+        echo "::set-output name=LOCAL_VERSION::v$localversion"
         echo "::set-output name=IS_RELEASE_REQUIRED::$isReleaseRequired"
       
     - name: Install Dotnet
@@ -41,4 +42,14 @@ jobs:
       if: steps.CheckReleaseRequired.outputs.IS_RELEASE_REQUIRED == 'true' 
       run: dotnet nuget push --skip-duplicate --api-key ${{secrets.NUGET_API_KEY}} --source 'https://api.nuget.org/v3/index.json' ./src/PrettyPrompt/bin/Release/PrettyPrompt.*.npkg
 
-    
+    - name: Create Git Tag
+      if: steps.CheckReleaseRequired.outputs.IS_RELEASE_REQUIRED == 'true' 
+      uses: actions/github-script@v6
+      with:
+        script: |
+          github.rest.git.createRef({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            ref: 'refs/tags/' + steps.CheckReleaseRequired.outputs.LOCAL_VERSION,
+            sha: context.sha
+          }) 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+# publishes to nuget if the version number in PrettyPrompt.csproj changes
+
+name: publish to nuget
+
+on:
+  push:
+    branches:
+    - main
+    
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    
+    - name: Check for new version
+      id: CheckReleaseRequired
+      shell: pwsh
+      run: |
+        $csproj = [xml](Get-Content ./src/PrettyPrompt/PrettyPrompt.csproj)
+        $localversion = $csproj.Project.PropertyGroup.Version[0]
+        $latestversion = (Invoke-RestMethod https://api.nuget.org/v3-flatcontainer/PrettyPrompt/index.json).versions | select -Last 1
+        $isReleaseRequired = ($localversion -ne $latestversion).ToString().ToLower()
+        echo "::set-output name=IS_RELEASE_REQUIRED::$isReleaseRequired"
+      
+    - name: Install Dotnet
+      uses: actions/setup-dotnet@v1
+      if: steps.CheckReleaseRequired.outputs.IS_RELEASE_REQUIRED == 'true' 
+      with:
+        dotnet-version: | 
+          5.0.x
+          6.0.x
+
+    - name: Create NuGet Package
+      if: steps.CheckReleaseRequired.outputs.IS_RELEASE_REQUIRED == 'true' 
+      run: dotnet pack ./src/PrettyPrompt/PrettyPrompt.csproj -c Release -p:ContinuousIntegrationBuild=true
+
+    - name: Publish to NuGet
+      if: steps.CheckReleaseRequired.outputs.IS_RELEASE_REQUIRED == 'true' 
+      run: dotnet nuget push --skip-duplicate --api-key ${{secrets.NUGET_API_KEY}} --source 'https://api.nuget.org/v3/index.json' ./src/PrettyPrompt/bin/Release/PrettyPrompt.*.npkg
+
+    

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,8 @@ jobs:
       run: |
         $csproj = [xml](Get-Content ./src/PrettyPrompt/PrettyPrompt.csproj)
         $localversion = $csproj.Project.PropertyGroup.Version[0]
-        $latestversion = (Invoke-RestMethod https://api.nuget.org/v3-flatcontainer/PrettyPrompt/index.json).versions | select -Last 1
-        $isReleaseRequired = ($localversion -ne $latestversion).ToString().ToLower()
+        $publishedversions = (Invoke-RestMethod https://api.nuget.org/v3-flatcontainer/PrettyPrompt/index.json).versions
+        $isReleaseRequired = (-not $publishedversions.Contains($localversion)).ToString().ToLower()
         echo "::set-output name=IS_RELEASE_REQUIRED::$isReleaseRequired"
       
     - name: Install Dotnet

--- a/src/PrettyPrompt/PrettyPrompt.csproj
+++ b/src/PrettyPrompt/PrettyPrompt.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>4.0.0</Version>
+    <Version>4.0.0-beta1</Version>
 
     <PackageId>PrettyPrompt</PackageId>
     <PackageTags>repl readline console cli</PackageTags>


### PR DESCRIPTION
When the `main` branch changes (e.g. via a pull request) this GitHub Action Workflow will check the `<Version>` in `PrettyPrompt.csproj`, and also the latest version published to NuGet. If the local version is not on NuGet, this GitHub Action will publish a new release to NuGet using the Version number in the CSPROJ file. It will also create a git tag with the version number.

I've added the `-beta` suffix to the current version number for testing. NuGet treats any version with a suffix as a prerelease: https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#pre-release-versions

This also changes the current version in the `main` branch from `4.0.0` to `4.0.0-beta1` because I think 4.0.0 is not yet ready to go out.
