### PR TITLE
Not rendering parameter description when empty. Args validation in OverloadItem.

### DIFF
--- a/src/PrettyPrompt/Completion/OverloadItem.cs
+++ b/src/PrettyPrompt/Completion/OverloadItem.cs
@@ -4,6 +4,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using PrettyPrompt.Highlighting;
@@ -23,12 +24,15 @@ public class OverloadItem
 
     public OverloadItem(FormattedString signature, FormattedString summary, FormattedString returnDescription, IReadOnlyList<Parameter> parameters)
     {
+        ArgumentNullException.ThrowIfNull(parameters);
+
         Signature = signature;
         Summary = summary;
         Return = returnDescription;
         Parameters = parameters;
     }
 
+    [DebuggerDisplay("{Name}: {Description}")]
     public readonly struct Parameter
     {
         public readonly string Name;
@@ -36,6 +40,8 @@ public class OverloadItem
 
         public Parameter(string name, FormattedString description)
         {
+            ArgumentNullException.ThrowIfNull(name);
+
             Name = name;
             Description = description;
         }

--- a/src/PrettyPrompt/Panes/OverloadPane.cs
+++ b/src/PrettyPrompt/Panes/OverloadPane.cs
@@ -132,8 +132,15 @@ internal class OverloadPane : IKeyPressHandler
             {
                 var paramIndex = selectedArgumentIndex.Clamp(0, selectedOverload.Parameters.Count - 1);
                 var param = selectedOverload.Parameters[paramIndex];
-                var name = new FormattedString(param.Name, new ConsoleFormat(Bold: true));
-                paramDescriptionLines = WordWrapping.WrapWords(spacesUnderCounter + name + ": " + param.Description, maxLength: availableWidth, maxLines: dedicatedLines[2]);
+                if (param.Description.IsEmpty)
+                {
+                    paramDescriptionLines = Array.Empty<FormattedString>();
+                }
+                else
+                {
+                    var name = new FormattedString(param.Name, new ConsoleFormat(Bold: true));
+                    paramDescriptionLines = WordWrapping.WrapWords(spacesUnderCounter + name + ": " + param.Description, maxLength: availableWidth, maxLines: dedicatedLines[2]);
+                }
             }
             else
             {

--- a/src/PrettyPrompt/PrettyPrompt.csproj
+++ b/src/PrettyPrompt/PrettyPrompt.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>4.0.0-beta8</Version>
+    <Version>4.0.0-beta9</Version>
 
     <PackageId>PrettyPrompt</PackageId>
     <PackageTags>repl readline console cli</PackageTags>


### PR DESCRIPTION
Resolves #216.
Resolves #217.