### PR TITLE
Fix paste when inserting text with newlines

### DIFF
--- a/src/PrettyPrompt/Panes/CodePane.cs
+++ b/src/PrettyPrompt/Panes/CodePane.cs
@@ -312,7 +312,7 @@ internal class CodePane : IKeyPressHandler
 
         //If we have text with consistent, leading indentation, trim that indentation ("dedent" it).
         //This handles the scenario where users are pasting from an IDE.
-        //Also replaces tabs as spaces and filtrs out special characters.
+        //Also replaces tabs as spaces and filters out special characters.
         string DedentMultipleLinesAndFilter(string text)
         {
             var sb = new StringBuilder();
@@ -326,7 +326,7 @@ internal class CodePane : IKeyPressHandler
                 //we remove indentation only when there are multiple non-whitespace lines
                 if (nonEmptyLines.Count <= 1)
                 {
-                    AppendFiltered(sb, text);
+                    AppendFiltered(sb, text); // don't trim on purpose due to https://github.com/waf/PrettyPrompt/issues/168
                 }
                 else
                 {
@@ -336,7 +336,11 @@ internal class CodePane : IKeyPressHandler
 
                     if (leadingIndent == 0)
                     {
-                        AppendFiltered(sb, text);
+                        for (var i = 0; i < lines.Length; i++)
+                        {
+                            AppendFiltered(sb, lines[i]);
+                            if (i != lines.Length - 1) sb.Append('\n');
+                        }
                     }
                     else
                     {

--- a/tests/PrettyPrompt.Tests/PromptTests.cs
+++ b/tests/PrettyPrompt.Tests/PromptTests.cs
@@ -262,6 +262,22 @@ public class PromptTests
         Assert.Equal($"indent{NewLine}    more indent{NewLine}{NewLine}indent", result.Text);
     }
 
+    [Fact]
+    public async Task ReadLine_Paste_TextWithNoLeadingIndentationPreservesNewlines()
+    {
+        var console = ConsoleStub.NewConsole();
+
+        console.KeyAvailable
+            .Returns(true, $"indent\r    more indent\r\rinden".Select(_ => true).Append(false).ToArray());
+        console.StubInput($"indent\r    more indent\r\rindent{Enter}");
+
+        var prompt = new Prompt(console: console);
+
+        var result = await prompt.ReadLineAsync();
+
+        Assert.Equal($"indent{NewLine}    more indent{NewLine}{NewLine}indent", result.Text);
+    }
+
     /// <summary>
     /// https://github.com/waf/PrettyPrompt/issues/168
     /// </summary>


### PR DESCRIPTION
Fix an issue where when pasting the following text:

```
class Dog
{
    public string Name { get; }
}
```

The newlines are omitted and results in a single line being pasted (`class Dog { public string Name { get; } }`)

Root issue is that the "trim leading spaces when text is pasted into prompt" logic does not treat text with no leading indentation correctly.