### PR TITLE
Do not draw empty documentation box when no completion item is selected.

### DIFF
--- a/src/PrettyPrompt/Rendering/Renderer.cs
+++ b/src/PrettyPrompt/Rendering/Renderer.cs
@@ -216,8 +216,11 @@ internal class Renderer : IDisposable
 
     private ScreenArea BuildDocumentationArea(CompletionPane completionPane, ConsoleCoordinate position)
     {
+        var documentation = completionPane.SelectedItemDocumentation;
+        if (documentation.Count == 0) return ScreenArea.Empty;
+
         var rows = boxDrawing.BuildFromLines(
-             completionPane.SelectedItemDocumentation,
+             documentation,
              configuration: configuration,
              background: configuration.CompletionItemDescriptionPaneBackground);
         return new ScreenArea(position, rows);


### PR DESCRIPTION
Resolves #232.