### PR TITLE
Support returning IAsyncEnumerable from a keybinding

### DIFF
--- a/tests/PrettyPrompt.Tests/PromptTests.cs
+++ b/tests/PrettyPrompt.Tests/PromptTests.cs
@@ -548,6 +548,36 @@ public class PromptTests
         Assert.Equal(callbackOutput, result);
     }
 
+    [Fact]
+    public async Task ReadLine_StreamingInputCallbackReturnsOutput_IsReturned()
+    {
+        var console = ConsoleStub.NewConsole();
+        console.StubInput($"Hello World{Control}{LeftArrow}{F5}{Enter}");
+
+        var callbackOutput = new StreamingInputCallbackResult(ResultAsync());
+        var prompt = new Prompt(
+            callbacks: new TestPromptCallbacks(
+            (
+                new KeyPressPattern(F5),
+                (inputArg, caretArg, _) =>
+                {
+                    return Task.FromResult<KeyPressCallbackResult?>(callbackOutput);
+                }
+            )),
+            console: console
+        );
+
+        var result = await prompt.ReadLineAsync();
+        Assert.Equal("Hello Asynchronous Streaming World", result.Text);
+
+        static async IAsyncEnumerable<string> ResultAsync()
+        {
+            await Task.Yield();
+            yield return "Asynchronous ";
+            yield return "Streaming ";
+        }
+    }
+
     /// <summary>
     /// https://github.com/waf/PrettyPrompt/issues/235
     /// </summary>


### PR DESCRIPTION
Introduces a new type to be returned from keybinding callbacks: `StreamingInputCallbackResult`. This type contains an `IAsyncEnumerable`. PrettyPrompt consumes the `IAsyncEnumerable` and draws the results to the screen.

The use case here is an OpenAI integration I'm working on for CSharpRepl. OpenAI streams the results in their API, which is responsible for their "word by word" output UI. By accepting/consuming an IAsyncEnumerable as a keybinding we can have a similar UI.

The contents streamed into our `Document` are done as a single `ChangeContext`, so pressing Undo will undo the entire stream (which is desirable in my opinion).