### PR TITLE
if the control modifier is pressed, don't insert the character

### DIFF
--- a/src/PrettyPrompt/Panes/CodePane.cs
+++ b/src/PrettyPrompt/Panes/CodePane.cs
@@ -285,7 +285,7 @@ internal class CodePane : IKeyPressHandler
                 }
                 break;
             default:
-                if (!char.IsControl(key.ConsoleKeyInfo.KeyChar))
+                if (!(char.IsControl(key.ConsoleKeyInfo.KeyChar) || key.ConsoleKeyInfo.Modifiers.HasFlag(Control)))
                 {
                     Document.InsertAtCaret(this, key.ConsoleKeyInfo.KeyChar);
                 }

--- a/tests/PrettyPrompt.Tests/ConsoleStub.cs
+++ b/tests/PrettyPrompt.Tests/ConsoleStub.cs
@@ -137,7 +137,8 @@ internal static class ConsoleStub
                     if (key.Value.StartsWith('{') && key.Value.EndsWith('}'))
                     {
                         var formatArgument = input.GetArgument(int.Parse(key.Value.Trim('{', '}')));
-                        modifiersPressed = AppendFormatStringArgument(list, key, modifiersPressed, formatArgument);
+                        var modifier = AppendFormatStringArgument(list, key, modifiersPressed, formatArgument);
+                        modifiersPressed = modifier == 0 ? 0 : modifiersPressed | modifier;
                     }
                     else
                     {

--- a/tests/PrettyPrompt.Tests/PromptTests.cs
+++ b/tests/PrettyPrompt.Tests/PromptTests.cs
@@ -552,13 +552,13 @@ public class PromptTests
     public async Task ReadLine_StreamingInputCallbackReturnsOutput_IsReturned()
     {
         var console = ConsoleStub.NewConsole();
-        console.StubInput($"Hello World{Control}{LeftArrow}{F5}{Enter}");
+        console.StubInput($"Hello World{Control}{LeftArrow}{Control}{Alt}{Spacebar}{Enter}");
 
         var callbackOutput = new StreamingInputCallbackResult(ResultAsync());
         var prompt = new Prompt(
             callbacks: new TestPromptCallbacks(
             (
-                new KeyPressPattern(F5),
+                new KeyPressPattern(Control | Alt, Spacebar),
                 (inputArg, caretArg, _) =>
                 {
                     return Task.FromResult<KeyPressCallbackResult?>(callbackOutput);


### PR DESCRIPTION
Currently, if the user sets up a keybinding like Ctrl-Alt-Space, a literal space will be typed into the prompt before firing the keybinding.

The fix is to not insert the character if Control is pressed. We still insert if Shift or Alt is pressed as these can result in valid letters.