### PR TITLE
Add input scrolling when content doesn't fit within the console window

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,17 +24,14 @@ jobs:
     - name: Dotnet Installation Info
       run: dotnet --info
       
-    - name: Install Codecov
-      run: dotnet tool install --global Codecov.Tool
-      
     - name: Build
       run: dotnet build
       
     - name: Test
-      run: dotnet test --collect:"XPlat Code Coverage" --settings tests\PrettyPrompt.Tests\TestCoverageRunSettings.xml
+      run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
 
-    - name: Code Coverage
-      shell: pwsh
-      run: |
-        $testCoverage = Get-ChildItem tests\PrettyPrompt.Tests\TestResults\*\*.xml
-        codecov -t ${{ secrets.CODECOV_TOKEN }} -f $testCoverage[0].ToString()
+    - name: Report Code Coverage
+      uses: codecov/codecov-action@260aa3b4b2f265b8578bc0e721e33ebf8ff53313
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: tests/PrettyPrompt.Tests/coverage.opencover.xml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,8 +18,8 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: | 
-          5.0.x
           6.0.x
+          7.0.x
       
     - name: Dotnet Installation Info
       run: dotnet --info

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,8 @@ jobs:
       if: steps.CheckReleaseRequired.outputs.IS_RELEASE_REQUIRED == 'true' 
       with:
         dotnet-version: | 
-          5.0.x
           6.0.x
+          7.0.x
 
     - name: Create NuGet Package
       if: steps.CheckReleaseRequired.outputs.IS_RELEASE_REQUIRED == 'true' 

--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,4 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+coverage.opencover.xml

--- a/src/PrettyPrompt/Rendering/ScreenArea.cs
+++ b/src/PrettyPrompt/Rendering/ScreenArea.cs
@@ -13,7 +13,7 @@ namespace PrettyPrompt;
 /// An area of the screen that's being rendered at a coordinate.
 /// This is conceptually a UI pane, rasterized into characters.
 /// </summary>
-internal sealed record ScreenArea(ConsoleCoordinate Start, Row[] Rows, bool TruncateToScreenHeight = true) : IDisposable
+internal sealed record ScreenArea(ConsoleCoordinate Start, Row[] Rows, bool TruncateToScreenHeight = true, int ViewPortStart = 0) : IDisposable
 {
     public static readonly ScreenArea Empty = new(ConsoleCoordinate.Zero, Array.Empty<Row>());
 

--- a/tests/PrettyPrompt.Benchmarks/PrettyPrompt.Benchmarks.csproj
+++ b/tests/PrettyPrompt.Benchmarks/PrettyPrompt.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/tests/PrettyPrompt.Tests/PrettyPrompt.Tests.csproj
+++ b/tests/PrettyPrompt.Tests/PrettyPrompt.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>

--- a/tests/PrettyPrompt.Tests/PrettyPrompt.Tests.csproj
+++ b/tests/PrettyPrompt.Tests/PrettyPrompt.Tests.csproj
@@ -19,6 +19,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="3.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/PrettyPrompt.Tests/RendererTests.cs
+++ b/tests/PrettyPrompt.Tests/RendererTests.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NSubstitute;
+using PrettyPrompt.Consoles;
+using PrettyPrompt.Panes;
+using TextCopy;
+using Xunit;
+
+namespace PrettyPrompt.Tests;
+
+public class RendererTests
+{
+    private const int ConsoleHeight = 5;
+    private readonly IConsole console;
+    private readonly PromptConfiguration configuration;
+    private readonly Renderer renderer;
+
+    public RendererTests()
+    {
+        this.console = ConsoleStub.NewConsole(width: 100, height: ConsoleHeight);
+        this.configuration = new PromptConfiguration();
+        this.renderer = new Renderer(console, configuration);
+    }
+
+    [Fact]
+    public void RenderOutput_ConsoleHeightTooSmall_ShowsTrailingLinesThatFitInViewport()
+    {
+        var typedInput = """
+            Console.WriteLine("A");
+            Console.WriteLine("B");
+            Console.WriteLine("C");
+            Console.WriteLine("D");
+            Console.WriteLine("E");
+            """.Replace("\r\n", "\n");
+
+        var (codePane, completionPane, overloadPane) = BuildUIPanes(typedInput);
+
+        // system under test
+        renderer.RenderOutput(
+            result: null,
+            codePane,
+            overloadPane,
+            completionPane,
+            Array.Empty<Highlighting.FormatSpan>(),
+            new KeyPress(new ConsoleKeyInfo(' ', ConsoleKey.Spacebar, false, false, false))
+        );
+
+        var output = GetRenderedOutput(console);
+
+        // because the console height is 5, with 2 lines of padding, and the cursor is on the final line,
+        // we should only render the last 3 lines.  there will be some ansi escape sequences for newlines here as well.
+        const string renderedNewlineWithCursorReposition = " \n[24D";
+        var expectedRender = string.Join(renderedNewlineWithCursorReposition, typedInput.Split('\n').TakeLast(ConsoleHeight - 2));
+        Assert.Equal(expectedRender, output);
+    }
+
+    [Fact]
+    public async Task RenderOutput_ConsoleHeightTooSmallAndCursorOnFirstLine_ShowsInitialLinesThatFitInViewport()
+    {
+        var typedInput = """
+            Console.WriteLine("A");
+            Console.WriteLine("B");
+            Console.WriteLine("C");
+            Console.WriteLine("D");
+            Console.WriteLine("E");
+            """.Replace("\r\n", "\n");
+
+        var (codePane, completionPane, overloadPane) = BuildUIPanes(typedInput);
+        // navigate to first line
+        await codePane.OnKeyDown(new KeyPress(new ConsoleKeyInfo('\0', ConsoleKey.Home, false, false, true)), CancellationToken.None);
+
+        // system under test
+        renderer.RenderOutput(
+            result: null,
+            codePane,
+            overloadPane,
+            completionPane,
+            Array.Empty<Highlighting.FormatSpan>(),
+            new KeyPress(new ConsoleKeyInfo(' ', ConsoleKey.Spacebar, false, false, false))
+        );
+
+        var output = GetRenderedOutput(console);
+
+        // because the console height is 5, with 2 lines of padding, with the cursor on the first line,
+        // we should only render the first 3 lines. There will be some ansi escape sequences for newlines here as well.
+        const string renderedNewlineWithCursorReposition = " \n[24D";
+        const string cursorRepositionToFirstLine = " \n[3A[24D";
+        var expectedRender = string.Join(renderedNewlineWithCursorReposition, typedInput.Split('\n').Take(ConsoleHeight - 2)) + cursorRepositionToFirstLine;
+        Assert.Equal(expectedRender, output);
+    }
+
+    private (CodePane codePane, CompletionPane completionPane, OverloadPane overloadPane) BuildUIPanes(string typedInput)
+    {
+        var callbacks = Substitute.For<IPromptCallbacks>();
+        var codePane = new CodePane(console, configuration, Substitute.For<IClipboard>());
+        codePane.Document.InsertAtCaret(codePane, typedInput);
+        var overloadPane = new OverloadPane(codePane, callbacks, configuration)
+        {
+            IsOpen = false
+        };
+        var completionPane = new CompletionPane(codePane, overloadPane, callbacks, configuration);
+        codePane.Bind(completionPane, overloadPane);
+        return (codePane, completionPane, overloadPane);
+    }
+
+    private static string? GetRenderedOutput(IConsole console)
+    {
+        var write = console.ReceivedCalls().Where(c => c.GetMethodInfo().Name == nameof(Console.Write)).Last();
+        var output = write.GetArguments()?.SingleOrDefault()?.ToString();
+        return output;
+    }
+}


### PR DESCRIPTION
If the input is too long to show in the console, allow scrolling around in the input based on keyboard navigation. Essentially it adds a "viewport" concept to the renderer based on the console's window height.

Relates to  #251 and possibly #257.