### PR TITLE
Fix altgr keyboard handling

### DIFF
--- a/src/PrettyPrompt/Panes/CodePane.cs
+++ b/src/PrettyPrompt/Panes/CodePane.cs
@@ -25,6 +25,7 @@ internal class CodePane : IKeyPressHandler
 {
     private readonly IConsole console;
     private readonly PromptConfiguration configuration;
+    private readonly IPromptCallbacks promptCallbacks;
     private readonly IClipboard clipboard;
     private readonly SelectionKeyPressHandler selectionHandler;
     private int topCoordinate;
@@ -113,10 +114,11 @@ internal class CodePane : IKeyPressHandler
         }
     }
 
-    public CodePane(IConsole console, PromptConfiguration configuration, IClipboard clipboard)
+    public CodePane(IConsole console, PromptConfiguration configuration, IPromptCallbacks promptCallbacks, IClipboard clipboard)
     {
         this.console = console;
         this.configuration = configuration;
+        this.promptCallbacks = promptCallbacks;
         this.clipboard = clipboard;
 
         MeasureConsole();
@@ -285,7 +287,7 @@ internal class CodePane : IKeyPressHandler
                 }
                 break;
             default:
-                if (!(char.IsControl(key.ConsoleKeyInfo.KeyChar) || key.ConsoleKeyInfo.Modifiers.HasFlag(Control)))
+                if (!(char.IsControl(key.ConsoleKeyInfo.KeyChar) || promptCallbacks.TryGetKeyPressCallbacks(key.ConsoleKeyInfo, out _)))
                 {
                     Document.InsertAtCaret(this, key.ConsoleKeyInfo.KeyChar);
                 }

--- a/src/PrettyPrompt/Prompt.cs
+++ b/src/PrettyPrompt/Prompt.cs
@@ -62,7 +62,7 @@ public sealed class Prompt : IPrompt, IAsyncDisposable
         using var renderer = new Renderer(console, configuration);
 
         // code pane contains the code the user is typing. It does not include the prompt (i.e. "> ")
-        var codePane = new CodePane(console, configuration, clipboard);
+        var codePane = new CodePane(console, configuration, promptCallbacks, clipboard);
 
         renderer.RenderPrompt(codePane);
 

--- a/tests/PrettyPrompt.Tests/RendererTests.cs
+++ b/tests/PrettyPrompt.Tests/RendererTests.cs
@@ -94,7 +94,7 @@ public class RendererTests
     private (CodePane codePane, CompletionPane completionPane, OverloadPane overloadPane) BuildUIPanes(string typedInput)
     {
         var callbacks = Substitute.For<IPromptCallbacks>();
-        var codePane = new CodePane(console, configuration, Substitute.For<IClipboard>());
+        var codePane = new CodePane(console, configuration, new PromptCallbacks(), Substitute.For<IClipboard>());
         codePane.Document.InsertAtCaret(codePane, typedInput);
         var overloadPane = new OverloadPane(codePane, callbacks, configuration)
         {


### PR DESCRIPTION
Previously, PR #252 was attempting to fix the scenario where users can have a Control-Alt-Space keybinding; the keybinding would be fired but the space key would be erroneously typed.

However, that PR broke AltGr handling. It assumed that filtering Ctrl to detect keybindings would be OK, and Alt keys would be unaffected. This is not correct, though, because AltGr is represented via Ctrl-Alt in C#, so it actually broke every AltGr based character, like curly-brace (`{`) on AZERTY keyboards.

This commit undoes the original fix for PR #252 and fixes it in a better way. Instead of assuming Ctrl is a keybinding, we use the actual configured keybindings in the filter, rather than assuming Ctrl represent a keybinding.