### PR TITLE
Add better linux clipboard error message

### DIFF
--- a/src/PrettyPrompt/Prompt.cs
+++ b/src/PrettyPrompt/Prompt.cs
@@ -15,6 +15,7 @@ using PrettyPrompt.Highlighting;
 using PrettyPrompt.History;
 using PrettyPrompt.Panes;
 using PrettyPrompt.Rendering;
+using PrettyPrompt.TextSelection;
 using TextCopy;
 
 namespace PrettyPrompt;
@@ -50,7 +51,7 @@ public sealed class Prompt : IPrompt, IAsyncDisposable
         this.configuration = configuration ?? new PromptConfiguration();
         this.history = new HistoryLog(persistentHistoryFilepath, this.configuration.KeyBindings);
         this.cancellationManager = new CancellationManager(this.console);
-        this.clipboard = (console is IConsoleWithClipboard consoleWithClipboard) ? consoleWithClipboard.Clipboard : new Clipboard();
+        this.clipboard = (console is IConsoleWithClipboard consoleWithClipboard) ? consoleWithClipboard.Clipboard : new WrappedClipboard();
 
         promptCallbacks = callbacks ?? new PromptCallbacks();
         this.highlighter = new SyntaxHighlighter(promptCallbacks, PromptConfiguration.HasUserOptedOutFromColor);

--- a/src/PrettyPrompt/TextSelection/WrappedClipboard.cs
+++ b/src/PrettyPrompt/TextSelection/WrappedClipboard.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using TextCopy;
+
+namespace PrettyPrompt.TextSelection;
+internal class WrappedClipboard : IClipboard
+{
+    private const string MissingExecutableError = "Could not execute process";
+    private const string HelpfulErrorMessage = "Could not access clipboard. Check that xsel (Linux) or clip.exe (WSL) is installed.";
+    private readonly Clipboard clipboard;
+
+    public WrappedClipboard()
+    {
+        this.clipboard = new Clipboard();
+    }
+
+    public string? GetText()
+    {
+        try
+        {
+            return clipboard.GetText();
+        }
+        catch (Exception ex) when (ex.Message.Contains(MissingExecutableError))
+        {
+            throw new Exception(HelpfulErrorMessage, ex);
+        }
+    }
+
+    public async Task<string?> GetTextAsync(CancellationToken cancellation = default)
+    {
+        try
+        {
+            return await clipboard.GetTextAsync(cancellation).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex.Message.Contains(MissingExecutableError))
+        {
+            throw new Exception(HelpfulErrorMessage, ex);
+        }
+    }
+
+    public void SetText(string text)
+    {
+        try
+        {
+            clipboard.SetText(text);
+        }
+        catch (Exception ex) when (ex.Message.Contains(MissingExecutableError))
+        {
+            throw new Exception(HelpfulErrorMessage, ex);
+        }
+    }
+
+    public async Task SetTextAsync(string text, CancellationToken cancellation = default)
+    {
+        try
+        {
+            await clipboard.SetTextAsync(text, cancellation).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex.Message.Contains(MissingExecutableError))
+        {
+            throw new Exception(HelpfulErrorMessage, ex);
+        }
+    }
+}

--- a/tests/PrettyPrompt.Tests/ClipboardTests.cs
+++ b/tests/PrettyPrompt.Tests/ClipboardTests.cs
@@ -1,0 +1,37 @@
+﻿using PrettyPrompt.TextSelection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PrettyPrompt.Tests;
+public class ClipboardTests
+{
+    private readonly WrappedClipboard clipboard;
+
+    public ClipboardTests()
+    {
+        this.clipboard = new WrappedClipboard();
+    }
+
+    [Fact]
+    public async Task Clipboard_WrappedCopyPasting()
+    {
+        var console = ConsoleStub.NewConsole();
+        using (console.ProtectClipboard())
+        {
+            clipboard.SetText("hello");
+            await Task.Delay(100);
+            var pasted = clipboard.GetText();
+            Assert.Equal("hello", pasted);
+
+            await clipboard.SetTextAsync("world");
+            await Task.Delay(100);
+            pasted = await clipboard.GetTextAsync();
+            Assert.Equal("world", pasted);
+        }
+    }
+
+}


### PR DESCRIPTION
prompt user to install xsel (linux) or clip.exe (WSL).

Closes https://github.com/waf/PrettyPrompt/issues/255