### PR TITLE
remove quick and dirty caching

### DIFF
--- a/src/PrettyPrompt/Highlighting/SyntaxHighlighter.cs
+++ b/src/PrettyPrompt/Highlighting/SyntaxHighlighter.cs
@@ -16,31 +16,19 @@ internal class SyntaxHighlighter
     private readonly IPromptCallbacks promptCallbacks;
     private readonly bool hasUserOptedOutFromColor;
 
-    // quick and dirty caching, mainly to handle cases where the user enters control
-    // characters (e.g. arrow keys, intellisense) that don't actually change the highlighted input
-    private string previousInput;
-    private IReadOnlyCollection<FormatSpan> previousOutput;
-
     public SyntaxHighlighter(IPromptCallbacks promptCallbacks, bool hasUserOptedOutFromColor)
     {
         this.promptCallbacks = promptCallbacks;
         this.hasUserOptedOutFromColor = hasUserOptedOutFromColor;
-        this.previousInput = string.Empty;
-        this.previousOutput = Array.Empty<FormatSpan>();
+        //this.previousInput = string.Empty;
+        //this.previousOutput = Array.Empty<FormatSpan>();
     }
 
     public async Task<IReadOnlyCollection<FormatSpan>> HighlightAsync(string input, CancellationToken cancellationToken)
     {
         if (hasUserOptedOutFromColor) return Array.Empty<FormatSpan>();
 
-        if (input.Equals(previousInput))
-        {
-            return previousOutput;
-        }
-
         var highlights = await promptCallbacks.HighlightCallbackAsync(input, cancellationToken).ConfigureAwait(false);
-        previousInput = input;
-        previousOutput = highlights;
         return highlights;
     }
 }


### PR DESCRIPTION
this PR removes the "quick and dirty caching" present in the [SyntaxHighlighter.cs](https://github.com/waf/PrettyPrompt/compare/main...CypherPotato:PrettyPrompt:main?expand=1#diff-148c294b5ccb06c34558c659544e59b29427a7e3c553d95dce74a9d348fa008a), this way, any key will force the component to re-render.

This sounds bad, but the cost is very low, and it makes it possible to render components when you "navigate" through the code, like highlighting matching brackets:

https://github.com/waf/PrettyPrompt/assets/17441745/9f7c27e8-b38a-4101-9742-5ff56381b6a4

[Example usage.](https://github.com/CypherPotato/motion/blob/master/cli/Program.cs#L213)