### PR TITLE
use InternalsVisibleTo

### DIFF
--- a/src/PrettyPrompt/PrettyPrompt.csproj
+++ b/src/PrettyPrompt/PrettyPrompt.csproj
@@ -34,14 +34,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-      <_Parameter1>PrettyPrompt.Tests</_Parameter1>
-    </AssemblyAttribute>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-      <_Parameter1>DynamicProxyGenAssembly2</_Parameter1>
-    </AssemblyAttribute>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-      <_Parameter1>PrettyPrompt.Benchmarks</_Parameter1>
-    </AssemblyAttribute>
+    <InternalsVisibleTo Include="PrettyPrompt.Tests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+    <InternalsVisibleTo Include="PrettyPrompt.Benchmarks" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
use `InternalsVisibleTo` msbuild item to simplify the assembly attribute
