### PR TITLE
Allow Alt+Enter to insert soft newline

### DIFF
--- a/src/PrettyPrompt/KeyBindings.cs
+++ b/src/PrettyPrompt/KeyBindings.cs
@@ -32,7 +32,7 @@ public class KeyBindings
     {
         CommitCompletion = Get(commitCompletion, new(Enter), new(Tab));
         TriggerCompletionList = Get(triggerCompletionList, new KeyPressPattern(Control, Spacebar));
-        NewLine = Get(newLine, new KeyPressPattern(Shift, Enter));
+        NewLine = Get(newLine, new KeyPressPattern(Shift, Enter), new KeyPressPattern(Alt, Enter));
         SubmitPrompt = Get(submitPrompt, new(Enter), new(Control, Enter), new(Control | Alt, Enter));
         HistoryPrevious = Get(historyPrevious, new KeyPressPattern(UpArrow));
         HistoryNext = Get(historyNext, new KeyPressPattern(DownArrow));


### PR DESCRIPTION
Claude Code remaps Shift+Enter to Alt+Enter in Windows Terminal. That has the side effect of breaking Shift+Enter in PrettyPrompt/CSharpRepl.