### PR TITLE
Better unicode handling

### DIFF
--- a/src/PrettyPrompt/Documents/Document.cs
+++ b/src/PrettyPrompt/Documents/Document.cs
@@ -225,10 +225,26 @@ internal class Document : IEquatable<Document>
     public WordWrappedText WrapEditableCharacters(int width)
         => WordWrapping.WrapEditableCharacters(stringBuilder, Caret, width);
 
+    /// <summary>Caret index one grapheme cluster to the left of the current caret (clamped to 0).</summary>
+    public int CalculateCaretIndexToLeft() => Grapheme.PreviousBoundary(currentText, Caret);
+
+    /// <summary>Caret index one grapheme cluster to the right of the current caret (clamped to Length).</summary>
+    public int CalculateCaretIndexToRight() => Grapheme.NextBoundary(currentText, Caret);
+
+    /// <summary>
+    /// Sets the caret to <paramref name="index"/>, snapping it back onto a grapheme-cluster boundary if it
+    /// landed inside a cluster (e.g. column-based vertical navigation into a wide character or emoji).
+    /// </summary>
+    public void SetCaretRoundedToGraphemeBoundary(int index) => Caret = Grapheme.RoundDownToBoundary(currentText, index);
+
     public void MoveToWordBoundary(int direction) =>
         Caret = CalculateWordBoundaryIndexNearCaret(direction);
 
     public int CalculateWordBoundaryIndexNearCaret(int direction)
+        // snap to a grapheme-cluster boundary so word navigation/deletion never lands inside a cluster
+        => Grapheme.RoundDownToBoundary(currentText, CalculateWordBoundaryIndexNearCaretCore(direction));
+
+    private int CalculateWordBoundaryIndexNearCaretCore(int direction)
     {
         if (direction == 0) throw new ArgumentOutOfRangeException(nameof(direction), "cannot be 0");
         direction = Math.Sign(direction);

--- a/src/PrettyPrompt/Documents/Grapheme.cs
+++ b/src/PrettyPrompt/Documents/Grapheme.cs
@@ -1,0 +1,71 @@
+#region License Header
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#endregion
+
+using System;
+using System.Globalization;
+
+namespace PrettyPrompt.Documents;
+
+/// <summary>
+/// Helpers for moving between grapheme-cluster boundaries in a string.
+///
+/// The document caret is a UTF-16 offset, but it should only ever rest on a grapheme-cluster
+/// boundary so that cursor movement and deletion operate on whole user-perceived characters -
+/// e.g. an emoji such as "🤦🏼‍♂️" (one cluster, seven <see cref="char"/>s) or a base letter plus
+/// combining marks - rather than splitting them into halves of a surrogate pair or orphaned
+/// combining marks. See https://github.com/waf/PrettyPrompt/issues/270.
+/// </summary>
+internal static class Grapheme
+{
+    /// <summary>
+    /// The smallest cluster boundary strictly greater than <paramref name="index"/>
+    /// (i.e. the caret position one grapheme to the right), clamped to the text length.
+    /// </summary>
+    public static int NextBoundary(string text, int index)
+    {
+        if (index < 0) index = 0;
+        if (index >= text.Length) return text.Length;
+        return index + StringInfo.GetNextTextElementLength(text, index);
+    }
+
+    /// <summary>
+    /// The largest cluster boundary strictly less than <paramref name="index"/>
+    /// (i.e. the caret position one grapheme to the left), clamped to 0.
+    /// </summary>
+    public static int PreviousBoundary(string text, int index)
+    {
+        if (index <= 0) return 0;
+        if (index > text.Length) index = text.Length;
+        int i = 0;
+        while (i < text.Length)
+        {
+            int next = i + StringInfo.GetNextTextElementLength(text, i);
+            if (next >= index) return i;
+            i = next;
+        }
+        return i;
+    }
+
+    /// <summary>
+    /// The largest cluster boundary less than or equal to <paramref name="index"/>. Snaps an index
+    /// that may have landed in the middle of a cluster (e.g. from column-based vertical navigation)
+    /// back onto a boundary, without moving it if it is already on one.
+    /// </summary>
+    public static int RoundDownToBoundary(string text, int index)
+    {
+        if (index <= 0) return 0;
+        if (index >= text.Length) return text.Length;
+        int i = 0;
+        while (i < text.Length)
+        {
+            int next = i + StringInfo.GetNextTextElementLength(text, i);
+            if (next == index) return index; // already on a boundary
+            if (next > index) return i;      // index is inside [i, next): snap back to the cluster start
+            i = next;
+        }
+        return i;
+    }
+}

--- a/src/PrettyPrompt/Documents/WordWrapping.cs
+++ b/src/PrettyPrompt/Documents/WordWrapping.cs
@@ -181,9 +181,11 @@ internal static class WordWrapping
                 lines.RemoveAt(lines.Count - 1);
                 if (maxLength > 3)
                 {
-                    Debug.Assert(lastLine.Length <= maxLength);
-                    lastLine = lastLine.Substring(0, Math.Min(maxLength - 3, lastLine.Length));
-                    lastLineModified = lastLine + new string('.', Math.Min(3, maxLength - lastLine.Length));
+                    Debug.Assert(lastLine.GetUnicodeWidth() <= maxLength);
+                    // reserve 3 columns for the ellipsis and truncate on a grapheme-cluster boundary by
+                    // display width (maxLength is a column budget, not a character count).
+                    lastLine = lastLine.Substring(0, UnicodeWidth.GetLengthThatFits(lastLine.Text, maxLength - 3));
+                    lastLineModified = lastLine + "...";
                 }
                 else
                 {

--- a/src/PrettyPrompt/Documents/WordWrapping.cs
+++ b/src/PrettyPrompt/Documents/WordWrapping.cs
@@ -50,7 +50,9 @@ internal static class WordWrapping
                 int unicodeWidth = UnicodeWidth.GetWidth(character);
                 if (unicodeWidth < 1)
                 {
-                    Debug.Fail("such character should not be present");
+                    // Zero-width scalars (combining marks, zero-width joiners, variation selectors, etc.)
+                    // are legitimate input - e.g. when pasting an emoji such as 🤦🏼‍♂️ - and advance
+                    // neither the line width nor the caret column. See issue #270.
                     continue;
                 }
                 currentLineLength += unicodeWidth;

--- a/src/PrettyPrompt/Documents/WordWrapping.cs
+++ b/src/PrettyPrompt/Documents/WordWrapping.cs
@@ -47,14 +47,12 @@ internal static class WordWrapping
                 bool isCursorPastCharacter = caret > textIndex;
 
                 Debug.Assert(character != '\t', "tabs should be replaced by spaces");
+                // Zero-width scalars (combining marks, zero-width joiners, variation selectors, etc.) are
+                // legitimate input - e.g. when pasting an emoji such as 🤦🏼‍♂️. They contribute no display
+                // width (so they don't grow the line or trigger wrapping), but they ARE part of the
+                // string/line content, so they must still advance textIndex (the string index) and the
+                // caret column just like any other character. See issue #270.
                 int unicodeWidth = UnicodeWidth.GetWidth(character);
-                if (unicodeWidth < 1)
-                {
-                    // Zero-width scalars (combining marks, zero-width joiners, variation selectors, etc.)
-                    // are legitimate input - e.g. when pasting an emoji such as 🤦🏼‍♂️ - and advance
-                    // neither the line width nor the caret column. See issue #270.
-                    continue;
-                }
                 currentLineLength += unicodeWidth;
                 textIndex++;
 

--- a/src/PrettyPrompt/GlobalUsings.cs
+++ b/src/PrettyPrompt/GlobalUsings.cs
@@ -1,0 +1,13 @@
+#region License Header
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#endregion
+
+// The source-only Wcwidth.Sources package compiles its files into this assembly and relies on
+// implicit usings. We provide just the namespaces it needs here rather than enabling project-wide
+// <ImplicitUsings>, which would also pull System.Net.Http and friends into the library.
+global using System;
+global using System.Collections.Generic;
+global using System.Linq;
+global using System.Text;

--- a/src/PrettyPrompt/Highlighting/FormattedString.cs
+++ b/src/PrettyPrompt/Highlighting/FormattedString.cs
@@ -290,11 +290,20 @@ public readonly struct FormattedString : IEquatable<FormattedString>
         while (partStart < text.Length)
         {
             int partLength = 0;
-            for (int i = partStart, partWidth = 0; i < text.Length; i++, partLength++)
             {
-                var cWidth = UnicodeWidth.GetWidth(text[i]);
-                partWidth += cWidth;
-                if (partWidth > chunkSize) break;
+                int partWidth = 0;
+                for (int i = partStart; i < text.Length;)
+                {
+                    int clusterLength = StringInfo.GetNextTextElementLength(text, i);
+                    int clusterWidth = UnicodeWidth.GetGraphemeClusterWidth(text.AsSpan(i, clusterLength));
+                    // stop before overflowing the chunk, but always emit at least one cluster so we make
+                    // progress even when a single wide cluster is larger than chunkSize. Splitting by raw
+                    // char count here could break a surrogate pair or grapheme cluster in two.
+                    if (partLength > 0 && partWidth + clusterWidth > chunkSize) break;
+                    partWidth += clusterWidth;
+                    i += clusterLength;
+                    partLength += clusterLength;
+                }
             }
 
             GenerateFormattingsForPart(partStart, partLength, partSeparatorLength: 0, ref usedFormattingCount, ref previousFormattingCharsUsed, formattingList);

--- a/src/PrettyPrompt/Panes/CodePane.cs
+++ b/src/PrettyPrompt/Panes/CodePane.cs
@@ -175,11 +175,11 @@ internal class CodePane : IKeyPressHandler
                 break;
             case (Shift, LeftArrow):
             case LeftArrow:
-                Document.Caret = Math.Max(0, Document.Caret - 1);
+                Document.Caret = Document.CalculateCaretIndexToLeft();
                 break;
             case (Shift, RightArrow):
             case RightArrow:
-                Document.Caret = Math.Min(Document.Length, Document.Caret + 1);
+                Document.Caret = Document.CalculateCaretIndexToRight();
                 break;
             case (Control | Shift, LeftArrow):
             case (Control, LeftArrow):
@@ -198,10 +198,18 @@ internal class CodePane : IKeyPressHandler
                 Document.Remove(this, Document.Caret, endDeleteIndex - Document.Caret);
                 break;
             case Backspace when selection is null:
-                Document.Remove(this, Document.Caret - 1, 1);
+                {
+                    // delete the whole grapheme cluster to the left, not a single UTF-16 code unit
+                    var clusterStart = Document.CalculateCaretIndexToLeft();
+                    Document.Remove(this, clusterStart, Document.Caret - clusterStart);
+                }
                 break;
             case Delete when selection is null:
-                Document.Remove(this, Document.Caret, 1);
+                {
+                    // delete the whole grapheme cluster to the right, not a single UTF-16 code unit
+                    var clusterEnd = Document.CalculateCaretIndexToRight();
+                    Document.Remove(this, Document.Caret, clusterEnd - Document.Caret);
+                }
                 break;
             case (_, Delete) or (_, Backspace) or Delete or Backspace when selection.HasValue:
                 {
@@ -419,7 +427,7 @@ internal class CodePane : IKeyPressHandler
                     var newCursor = Cursor.MoveUp();
                     var aboveLine = WordWrappedLines[newCursor.Row];
                     Cursor = newCursor.WithColumn(Math.Min(aboveLine.Content.AsSpan().TrimEnd().Length, newCursor.Column));
-                    Document.Caret = aboveLine.StartIndex + Cursor.Column;
+                    Document.SetCaretRoundedToGraphemeBoundary(aboveLine.StartIndex + Cursor.Column);
                     key.Handled = true;
                     break;
                 }
@@ -429,7 +437,7 @@ internal class CodePane : IKeyPressHandler
                     var newCursor = Cursor.MoveDown();
                     var belowLine = WordWrappedLines[newCursor.Row];
                     Cursor = newCursor.WithColumn(Math.Min(belowLine.Content.AsSpan().TrimEnd().Length, newCursor.Column));
-                    Document.Caret = belowLine.StartIndex + Cursor.Column;
+                    Document.SetCaretRoundedToGraphemeBoundary(belowLine.StartIndex + Cursor.Column);
                     key.Handled = true;
                     break;
                 }

--- a/src/PrettyPrompt/Panes/CodePane.cs
+++ b/src/PrettyPrompt/Panes/CodePane.cs
@@ -373,16 +373,22 @@ internal class CodePane : IKeyPressHandler
                 {
                     sb.Append(TabSpaces);
                 }
+                else if (c == '\n')
+                {
+                    sb.Append(c); // preserve newlines (multi-line paste)
+                }
+                else if (char.IsControl(c))
+                {
+                    // Strip other control characters (e.g. \r, NUL, ESC) that would corrupt terminal
+                    // rendering. We must NOT filter by display width here: zero-width scalars such as
+                    // combining marks, zero-width joiners, and variation selectors are legitimate parts
+                    // of grapheme clusters (e.g. the emoji sequence 🤦🏼‍♂️), and dropping them breaks the
+                    // cluster apart. See issue #270.
+                    continue;
+                }
                 else
                 {
-                    if (UnicodeWidth.GetWidth(c) >= 1)
-                    {
-                        sb.Append(c);
-                    }
-                    else
-                    {
-                        continue;
-                    }
+                    sb.Append(c);
                 }
             }
         }

--- a/src/PrettyPrompt/Panes/CompletionPane.cs
+++ b/src/PrettyPrompt/Panes/CompletionPane.cs
@@ -104,7 +104,10 @@ internal class CompletionPane : IKeyPressHandler
                     await Close(cancellationToken).ConfigureAwait(false);
                     return;
                 case LeftArrow or RightArrow:
-                    int caretNew = documentCaret + (key.ConsoleKeyInfo.Key == LeftArrow ? -1 : 1);
+                    // mirror the document's grapheme-cluster-aware caret movement (see CodePane arrow handling)
+                    int caretNew = key.ConsoleKeyInfo.Key == LeftArrow
+                        ? codePane.Document.CalculateCaretIndexToLeft()
+                        : codePane.Document.CalculateCaretIndexToRight();
                     if (caretNew < spanToReplace.Start || caretNew > spanToReplace.Start + spanToReplace.Length)
                     {
                         await Close(cancellationToken).ConfigureAwait(false);

--- a/src/PrettyPrompt/PrettyPrompt.csproj
+++ b/src/PrettyPrompt/PrettyPrompt.csproj
@@ -26,11 +26,16 @@
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
+    <!-- Compile the source-only Wcwidth.Sources types as internal so they don't leak into our public API. -->
+    <DefineConstants>$(DefineConstants);WCWIDTH_VISIBILITY_INTERNAL</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="TextCopy" Version="6.2.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <!-- Source-only package (compiles into PrettyPrompt.dll, no transitive runtime dependency).
+         WCWIDTH_VISIBILITY_INTERNAL keeps its types internal so they don't leak into our public API. -->
+    <PackageReference Include="Wcwidth.Sources" Version="4.0.1" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PrettyPrompt/Rendering/BoxDrawing.cs
+++ b/src/PrettyPrompt/Rendering/BoxDrawing.cs
@@ -161,7 +161,10 @@ internal class BoxDrawing
         {
             row = new Row(boxWidth);
             var line = lineList[i];
-            FillLineRow(row, line.Substring(0, Math.Min(line.Length, lineAvailableWidth)), i, background);
+            // truncate to the available column width on a grapheme-cluster boundary - lineAvailableWidth is
+            // a display-width budget, not a character count, so slicing by char count would overflow the box
+            // for wide characters and could split a surrogate pair or cluster.
+            FillLineRow(row, line.Substring(0, UnicodeWidth.GetLengthThatFits(line.Text, lineAvailableWidth)), i, background);
             rows.Add(row);
         }
 

--- a/src/PrettyPrompt/Rendering/Screen.cs
+++ b/src/PrettyPrompt/Rendering/Screen.cs
@@ -5,7 +5,6 @@
 #endregion
 
 using System;
-using System.Diagnostics;
 using System.Linq;
 using PrettyPrompt.Consoles;
 
@@ -85,26 +84,37 @@ internal sealed class Screen : IDisposable
         if (screen.CellBuffer.Length == 0) return cursor;
 
         int row = Math.Min(cursor.Row, screen.Height - 1);
-        int column = Math.Min(cursor.Column, screen.Width - 1);
+        int charColumn = Math.Min(cursor.Column, screen.Width - 1);
         int rowStartIndex = row * screen.Width;
-        int rowCursorIndex = rowStartIndex + column;
-        int extraColumnOffset = 0;
-        for (int i = row * screen.Width; i <= rowCursorIndex + extraColumnOffset; i++)
+
+        // cursor.Column is a char index (UTF-16 offset) within the row. Convert it to a display column by
+        // walking the row's cells and summing each cell's ElementWidth (columns it occupies) while counting
+        // its Text.Length (chars it consumes). This handles every cluster shape:
+        //   '界'  -> 1 char, 2 columns      (wide)
+        //   '😀'  -> 2 chars, 2 columns     (surrogate pair)
+        //   '🤦🏼‍♂️' -> 7 chars, 2 columns     (ZWJ emoji sequence)
+        //   'é' (e + combining accent) -> 2 chars, 1 column (combining cluster)
+        int chars = 0;
+        int displayColumn = 0;
+        for (int i = rowStartIndex; i < rowStartIndex + screen.Width && chars < charColumn; i++)
         {
             var cell = screen.CellBuffer[i];
-            if (cell is not null && cell.IsContinuationOfPreviousCharacter)
+            if (cell is null)
             {
-                Debug.Assert(i > 0);
-                var previousCell = screen.CellBuffer[i - 1];
-                Debug.Assert(previousCell?.Text is not null);
-                Debug.Assert(previousCell.ElementWidth == 2);
-
-                //e.g. for '界' is previousCell.ElementWidth==2 and previousCell.Text.Length==1
-                //e.g. for '😀' is previousCell.ElementWidth==2 and previousCell.Text.Length==2 (which means cursor is already moved by 2 because of Text length)
-                extraColumnOffset += previousCell.ElementWidth - previousCell.Text.Length;
+                // an empty cell is rendered as a single space: one char, one column
+                chars++;
+                displayColumn++;
+            }
+            else if (!cell.IsContinuationOfPreviousCharacter)
+            {
+                // continuation cells carry no text/width of their own - they're accounted for by the
+                // ElementWidth of their main cell, so we only advance on main cells.
+                chars += cell.Text?.Length ?? 1;
+                displayColumn += cell.ElementWidth;
             }
         }
-        int newColumn = column + extraColumnOffset;
+
+        int newColumn = displayColumn;
         int newRow = cursor.Row - ViewPortOffset;
 
         return newColumn > screen.Width

--- a/src/PrettyPrompt/Rendering/UnicodeWidth.cs
+++ b/src/PrettyPrompt/Rendering/UnicodeWidth.cs
@@ -73,6 +73,28 @@ public static class UnicodeWidth
         return Clamp(UnicodeCalculator.GetWidth(baseRune));
     }
 
+    /// <summary>
+    /// Returns the number of leading <see cref="char"/>s of <paramref name="text"/> whose combined
+    /// display width does not exceed <paramref name="maxWidth"/> columns. The returned length always
+    /// falls on a grapheme-cluster boundary, so slicing the text at it never splits a cluster or a
+    /// surrogate pair. Use this for width-bounded truncation instead of slicing by raw character count.
+    /// </summary>
+    public static int GetLengthThatFits(ReadOnlySpan<char> text, int maxWidth)
+    {
+        if (maxWidth <= 0) return 0;
+        int width = 0;
+        int i = 0;
+        while (i < text.Length)
+        {
+            int elementLength = StringInfo.GetNextTextElementLength(text.Slice(i));
+            int elementWidth = GetGraphemeClusterWidth(text.Slice(i, elementLength));
+            if (width + elementWidth > maxWidth) break;
+            width += elementWidth;
+            i += elementLength;
+        }
+        return i;
+    }
+
     // wcwidth returns -1 for control characters; PrettyPrompt renders those as zero width. The renderer
     // models a cell as at most two columns, so never let a single element exceed that.
     private static int Clamp(int wcwidth) => wcwidth < 0 ? 0 : Math.Min(wcwidth, 2);

--- a/src/PrettyPrompt/Rendering/UnicodeWidth.cs
+++ b/src/PrettyPrompt/Rendering/UnicodeWidth.cs
@@ -1,254 +1,79 @@
-﻿/*
- * https://gist.github.com/gongdo/0275b9ad1f25ad9d6f7a92ff677f5ec0
- *
- * This is an implementation of wcwidth() and wcswidth() (defined in
- * IEEE Std 1002.1-2001) for Unicode.
- *
- * http://www.opengroup.org/onlinepubs/007904975/functions/wcwidth.html
- * http://www.opengroup.org/onlinepubs/007904975/functions/wcswidth.html
- *
- * In fixed-width output devices, Latin characters all occupy a single
- * "cell" position of equal width, whereas ideographic CJK characters
- * occupy two such cells. Interoperability between terminal-line
- * applications and (teletype-style) character terminals using the
- * UTF-8 encoding requires agreement on which character should advance
- * the cursor by how many cell positions. No established formal
- * standards exist at present on which Unicode character shall occupy
- * how many cell positions on character terminals. These routines are
- * a first attempt of defining such behavior based on simple rules
- * applied to data provided by the Unicode Consortium.
- *
- * For some graphical characters, the Unicode standard explicitly
- * defines a character-cell width via the definition of the East Asian
- * FullWidth (F), Wide (W), Half-width (H), and Narrow (Na) classes.
- * In all these cases, there is no ambiguity about which width a
- * terminal shall use. For characters in the East Asian Ambiguous (A)
- * class, the width choice depends purely on a preference of backward
- * compatibility with either historic CJK or Western practice.
- * Choosing single-width for these characters is easy to justify as
- * the appropriate long-term solution, as the CJK practice of
- * displaying these characters as double-width comes from historic
- * implementation simplicity (8-bit encoded characters were displayed
- * single-width and 16-bit ones double-width, even for Greek,
- * Cyrillic, etc.) and not any typographic considerations.
- *
- * Much less clear is the choice of width for the Not East Asian
- * (Neutral) class. Existing practice does not dictate a width for any
- * of these characters. It would nevertheless make sense
- * typographically to allocate two character cells to characters such
- * as for instance EM SPACE or VOLUME INTEGRAL, which cannot be
- * represented adequately with a single-width glyph. The following
- * routines at present merely assign a single-cell width to all
- * neutral characters, in the interest of simplicity. This is not
- * entirely satisfactory and should be reconsidered before
- * establishing a formal standard in this area. At the moment, the
- * decision which Not East Asian (Neutral) characters should be
- * represented by double-width glyphs cannot yet be answered by
- * applying a simple rule from the Unicode database content. Setting
- * up a proper standard for the behavior of UTF-8 character terminals
- * will require a careful analysis not only of each Unicode character,
- * but also of each presentation form, something the author of these
- * routines has avoided to do so far.
- *
- * http://www.unicode.org/unicode/reports/tr11/
- *
- * Markus Kuhn -- 2007-05-26 (Unicode 5.0)
- *
- * Permission to use, copy, modify, and distribute this software
- * for any purpose and without fee is hereby granted. The author
- * disclaims all warranties with regard to this software.
- *
- * Latest version: http://www.cl.cam.ac.uk/~mgk25/ucs/wcwidth.c
- */
+#region License Header
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#endregion
+
 using System;
-using System.Collections.Generic;
-using System.Linq;
+using System.Buffers;
+using System.Globalization;
+using System.Text;
+using Wcwidth;
 
 namespace PrettyPrompt.Rendering;
 
+/// <summary>
+/// Calculates how many terminal columns ("cells") a character or string occupies.
+///
+/// <para>
+/// Per-scalar widths come from <see cref="UnicodeCalculator"/> — a vendored, source-only copy of
+/// https://github.com/spectreconsole/wcwidth (Unicode 16). PrettyPrompt layers grapheme-cluster
+/// awareness on top: a cluster (an emoji ZWJ sequence such as "🤦🏼‍♂️", or a base character followed
+/// by combining marks / a variation selector) occupies the width of its <b>base scalar value</b> — the
+/// trailing scalars modify the glyph but add no columns. Each cluster's width is capped at 2, because
+/// the renderer models every cell as one or two columns wide (see <see cref="Cell"/>); without the cap,
+/// summing the parts of a cluster (e.g. base + skin-tone modifier = 2 + 2) produced widths of 3-5 and
+/// crashed cursor positioning. See https://github.com/waf/PrettyPrompt/issues/270.
+/// </para>
+/// </summary>
 public static class UnicodeWidth
 {
-    private readonly struct Interval
-    {
-        public int First { get; }
-        public int Last { get; }
-
-        public Interval(int first, int last)
-        {
-            First = first;
-            Last = last;
-        }
-    };
-
-    /* auxiliary function for binary search in interval table */
-    private static bool BinarySearch(char ucs, Interval[] table)
-    {
-        int min = 0;
-        int max = table.Length - 1;
-        int mid;
-
-        if (ucs < table[0].First || ucs > table[max].Last)
-            return false;
-        while (max >= min)
-        {
-            mid = (min + max) / 2;
-            if (ucs > table[mid].Last)
-                min = mid + 1;
-            else if (ucs < table[mid].First)
-                max = mid - 1;
-            else
-                return true;
-        }
-
-        return false;
-    }
-
-    /* sorted list of non-overlapping intervals of non-spacing characters */
-    /* generated by "uniset +cat=Me +cat=Mn +cat=Cf -00AD +1160-11FF +200B c" */
-    private static readonly Interval[] combining = new Dictionary<int, int> {
-            { 0x0300, 0x036F }, { 0x0483, 0x0486 }, { 0x0488, 0x0489 },
-            { 0x0591, 0x05BD }, { 0x05BF, 0x05BF }, { 0x05C1, 0x05C2 },
-            { 0x05C4, 0x05C5 }, { 0x05C7, 0x05C7 }, { 0x0600, 0x0603 },
-            { 0x0610, 0x0615 }, { 0x064B, 0x065E }, { 0x0670, 0x0670 },
-            { 0x06D6, 0x06E4 }, { 0x06E7, 0x06E8 }, { 0x06EA, 0x06ED },
-            { 0x070F, 0x070F }, { 0x0711, 0x0711 }, { 0x0730, 0x074A },
-            { 0x07A6, 0x07B0 }, { 0x07EB, 0x07F3 }, { 0x0901, 0x0902 },
-            { 0x093C, 0x093C }, { 0x0941, 0x0948 }, { 0x094D, 0x094D },
-            { 0x0951, 0x0954 }, { 0x0962, 0x0963 }, { 0x0981, 0x0981 },
-            { 0x09BC, 0x09BC }, { 0x09C1, 0x09C4 }, { 0x09CD, 0x09CD },
-            { 0x09E2, 0x09E3 }, { 0x0A01, 0x0A02 }, { 0x0A3C, 0x0A3C },
-            { 0x0A41, 0x0A42 }, { 0x0A47, 0x0A48 }, { 0x0A4B, 0x0A4D },
-            { 0x0A70, 0x0A71 }, { 0x0A81, 0x0A82 }, { 0x0ABC, 0x0ABC },
-            { 0x0AC1, 0x0AC5 }, { 0x0AC7, 0x0AC8 }, { 0x0ACD, 0x0ACD },
-            { 0x0AE2, 0x0AE3 }, { 0x0B01, 0x0B01 }, { 0x0B3C, 0x0B3C },
-            { 0x0B3F, 0x0B3F }, { 0x0B41, 0x0B43 }, { 0x0B4D, 0x0B4D },
-            { 0x0B56, 0x0B56 }, { 0x0B82, 0x0B82 }, { 0x0BC0, 0x0BC0 },
-            { 0x0BCD, 0x0BCD }, { 0x0C3E, 0x0C40 }, { 0x0C46, 0x0C48 },
-            { 0x0C4A, 0x0C4D }, { 0x0C55, 0x0C56 }, { 0x0CBC, 0x0CBC },
-            { 0x0CBF, 0x0CBF }, { 0x0CC6, 0x0CC6 }, { 0x0CCC, 0x0CCD },
-            { 0x0CE2, 0x0CE3 }, { 0x0D41, 0x0D43 }, { 0x0D4D, 0x0D4D },
-            { 0x0DCA, 0x0DCA }, { 0x0DD2, 0x0DD4 }, { 0x0DD6, 0x0DD6 },
-            { 0x0E31, 0x0E31 }, { 0x0E34, 0x0E3A }, { 0x0E47, 0x0E4E },
-            { 0x0EB1, 0x0EB1 }, { 0x0EB4, 0x0EB9 }, { 0x0EBB, 0x0EBC },
-            { 0x0EC8, 0x0ECD }, { 0x0F18, 0x0F19 }, { 0x0F35, 0x0F35 },
-            { 0x0F37, 0x0F37 }, { 0x0F39, 0x0F39 }, { 0x0F71, 0x0F7E },
-            { 0x0F80, 0x0F84 }, { 0x0F86, 0x0F87 }, { 0x0F90, 0x0F97 },
-            { 0x0F99, 0x0FBC }, { 0x0FC6, 0x0FC6 }, { 0x102D, 0x1030 },
-            { 0x1032, 0x1032 }, { 0x1036, 0x1037 }, { 0x1039, 0x1039 },
-            { 0x1058, 0x1059 }, { 0x1160, 0x11FF }, { 0x135F, 0x135F },
-            { 0x1712, 0x1714 }, { 0x1732, 0x1734 }, { 0x1752, 0x1753 },
-            { 0x1772, 0x1773 }, { 0x17B4, 0x17B5 }, { 0x17B7, 0x17BD },
-            { 0x17C6, 0x17C6 }, { 0x17C9, 0x17D3 }, { 0x17DD, 0x17DD },
-            { 0x180B, 0x180D }, { 0x18A9, 0x18A9 }, { 0x1920, 0x1922 },
-            { 0x1927, 0x1928 }, { 0x1932, 0x1932 }, { 0x1939, 0x193B },
-            { 0x1A17, 0x1A18 }, { 0x1B00, 0x1B03 }, { 0x1B34, 0x1B34 },
-            { 0x1B36, 0x1B3A }, { 0x1B3C, 0x1B3C }, { 0x1B42, 0x1B42 },
-            { 0x1B6B, 0x1B73 }, { 0x1DC0, 0x1DCA }, { 0x1DFE, 0x1DFF },
-            { 0x200B, 0x200F }, { 0x202A, 0x202E }, { 0x2060, 0x2063 },
-            { 0x206A, 0x206F }, { 0x20D0, 0x20EF }, { 0x302A, 0x302F },
-            { 0x3099, 0x309A }, { 0xA806, 0xA806 }, { 0xA80B, 0xA80B },
-            { 0xA825, 0xA826 }, { 0xFB1E, 0xFB1E }, { 0xFE00, 0xFE0F },
-            { 0xFE20, 0xFE23 }, { 0xFEFF, 0xFEFF }, { 0xFFF9, 0xFFFB },
-            { 0x10A01, 0x10A03 }, { 0x10A05, 0x10A06 }, { 0x10A0C, 0x10A0F },
-            { 0x10A38, 0x10A3A }, { 0x10A3F, 0x10A3F }, { 0x1D167, 0x1D169 },
-            { 0x1D173, 0x1D182 }, { 0x1D185, 0x1D18B }, { 0x1D1AA, 0x1D1AD },
-            { 0x1D242, 0x1D244 }, { 0xE0001, 0xE0001 }, { 0xE0020, 0xE007F },
-            { 0xE0100, 0xE01EF }
-        }.Select(item => new Interval(item.Key, item.Value)).ToArray();
-
-    /* The following two functions define the column width of an ISO 10646
-    * character as follows:
-    *
-    *    - The null character (U+0000) has a column width of 0.
-    *
-    *    - Other C0/C1 control characters and DEL will lead to a return
-    *      value of -1. PrettyPrompt: we use 0.
-    *
-    *    - Non-spacing and enclosing combining characters (general
-    *      category code Mn or Me in the Unicode database) have a
-    *      column width of 0.
-    *
-    *    - SOFT HYPHEN (U+00AD) has a column width of 1.
-    *
-    *    - Other format characters (general category code Cf in the Unicode
-    *      database) and ZERO WIDTH SPACE (U+200B) have a column width of 0.
-    *
-    *    - Hangul Jamo medial vowels and final consonants (U+1160-U+11FF)
-    *      have a column width of 0.
-    *
-    *    - Spacing characters in the East Asian Wide (W) or East Asian
-    *      Full-width (F) category as defined in Unicode Technical
-    *      Report #11 have a column width of 2.
-    *
-    *    - All remaining characters (including all printable
-    *      ISO 8859-1 and WGL4 characters, Unicode control characters,
-    *      etc.) have a column width of 1.
-    *
-    * This implementation assumes that wchar_t characters are encoded
-    * in ISO 10646.
-    */
-
+    /// <summary>
+    /// Width of a single UTF-16 code unit. Used by the caret/word-wrap paths that walk text by
+    /// <see cref="char"/> (i.e. by string index), so each half of a surrogate pair counts as one column.
+    /// For whole strings or grapheme clusters use <see cref="GetWidth(ReadOnlySpan{char})"/> or
+    /// <see cref="GetGraphemeClusterWidth(ReadOnlySpan{char})"/> instead.
+    /// </summary>
     public static int GetWidth(char character)
     {
-        /* test for 8-bit control characters */
-        if (character == 0)
-            return 0;
-        if (character == 10) // PrettyPrompt addition, handle newline. This is a bit suspect.
-            return 1;
-        if (character < 32 || (character >= 0x7f && character < 0xa0))
-            //return -1;
-            return 0; //PrettyPrompt
-
-        // the following two conditions were added for PrettyPrompt fast paths.
-        if (character < 0x0300) // frequent character fast path
-            return 1;
-        if (character >= 0x2500 && character <= 0x257F) // fast path for box drawing
-            return 1;
-
-        /* binary search in table of non-spacing characters */
-        if (BinarySearch(character, combining))
-            return 0;
-
-        //PrettyPrompt's correction
-        if ((int)character is
-            0x26AA or //⚫
-            0x26AB or //⚪
-            0x2B55 or //⭕
-            0x26A1 or //⚡
-            0x2B1B or //⬛
-            0x2B1C or //⬜
-            0x274C or //❌
-            0x2705    //✅
-            )
-        {
-            return 2;
-        }
-
-        /* if we arrive here, ucs is not a combining or C0/C1 control character */
-        return (character >= 0x1100 &&
-            (character <= 0x115f ||                    /* Hangul Jamo init. consonants */
-            character == 0x2329 || character == 0x232a ||
-            (character >= 0x2e80 && character <= 0xa4cf &&
-                character != 0x303f) ||                  /* CJK ... Yi */
-            (character >= 0xac00 && character <= 0xd7a3) || /* Hangul Syllables */
-            (character >= 0xf900 && character <= 0xfaff) || /* CJK Compatibility Ideographs */
-            (character >= 0xfe10 && character <= 0xfe19) || /* Vertical forms */
-            (character >= 0xfe30 && character <= 0xfe6f) || /* CJK Compatibility Forms */
-            (character >= 0xff00 && character <= 0xff60) || /* Fullwidth Forms */
-            (character >= 0xffe0 && character <= 0xffe6) ||
-            (character >= 0x20000 && character <= 0x2fffd) ||
-            (character >= 0x30000 && character <= 0x3fffd)))
-            ? 2 : 1;
+        if (character == '\n') return 1; // PrettyPrompt: treat newline as occupying a single column.
+        if (char.IsSurrogate(character)) return 1; // half of a surrogate pair; the pair sums to the scalar's width.
+        return Clamp(UnicodeCalculator.GetWidth(character));
     }
 
+    /// <summary>
+    /// Total display width of <paramref name="text"/>, summed over its grapheme clusters so the result
+    /// matches the number of cells the renderer produces for it.
+    /// </summary>
     public static int GetWidth(ReadOnlySpan<char> text)
     {
         int width = 0;
-        for (int i = 0; i < text.Length; i++)
+        while (!text.IsEmpty)
         {
-            int w = GetWidth(text[i]);
-            width += w;
+            int elementLength = StringInfo.GetNextTextElementLength(text);
+            width += GetGraphemeClusterWidth(text.Slice(0, elementLength));
+            text = text.Slice(elementLength);
         }
         return width;
     }
+
+    /// <summary>
+    /// Display width (0, 1, or 2 columns) of a single grapheme cluster, determined by its base scalar
+    /// value. Trailing combining marks, zero-width joiners, emoji modifiers, and variation selectors are
+    /// part of the same cluster and contribute no additional columns. Capped at 2 to match the cell model.
+    /// </summary>
+    public static int GetGraphemeClusterWidth(ReadOnlySpan<char> cluster)
+    {
+        if (cluster.IsEmpty) return 0;
+        if (Rune.DecodeFromUtf16(cluster, out var baseRune, out _) != OperationStatus.Done)
+        {
+            return 1; // ill-formed (e.g. a lone surrogate); be defensive and reserve a single column.
+        }
+        if (baseRune.Value == '\n') return 1;
+        return Clamp(UnicodeCalculator.GetWidth(baseRune));
+    }
+
+    // wcwidth returns -1 for control characters; PrettyPrompt renders those as zero width. The renderer
+    // models a cell as at most two columns, so never let a single element exceed that.
+    private static int Clamp(int wcwidth) => wcwidth < 0 ? 0 : Math.Min(wcwidth, 2);
 }

--- a/src/PrettyPrompt/StringCache.cs
+++ b/src/PrettyPrompt/StringCache.cs
@@ -51,7 +51,9 @@ internal sealed class StringCache
         else
         {
             var result = characters.ToString();
-            unicodeWidth = UnicodeWidth.GetWidth(result);
+            // 'characters' is always a single grapheme cluster (see Cell.AddTo), so its cell width is
+            // the width of the cluster's base scalar, capped at 2 — not the sum of its code units.
+            unicodeWidth = UnicodeWidth.GetGraphemeClusterWidth(characters);
             return result;
         }
     }

--- a/tests/PrettyPrompt.Tests/FormattedStringTests.cs
+++ b/tests/PrettyPrompt.Tests/FormattedStringTests.cs
@@ -304,4 +304,23 @@ public class FormattedStringTests
             return list;
         }
     }
+
+    [Fact]
+    public void SplitIntoChunks_DoesNotSplitGraphemeClusters()
+    {
+        // 🤦🏼‍♂️ is one grapheme cluster (7 chars, display width 2). Widths: a1 b1 emoji2 c1 d1 = 6.
+        const string Emoji = "\U0001F926\U0001F3FC\u200D\u2642\uFE0F";
+        var text = "ab" + Emoji + "cd";
+        var chunks = new FormattedString(text).SplitIntoChunks(3).Select(c => c.Text!).ToList();
+
+        // chunks reassemble to the original, the emoji lives wholly within one chunk, and no chunk
+        // begins/ends with an orphaned surrogate half (which would mean a cluster was split).
+        Assert.Equal(text, string.Concat(chunks));
+        Assert.Contains(chunks, c => c.Contains(Emoji));
+        foreach (var chunk in chunks)
+        {
+            Assert.False(char.IsLowSurrogate(chunk[0]), "chunk starts with an orphaned low surrogate");
+            Assert.False(char.IsHighSurrogate(chunk[^1]), "chunk ends with an orphaned high surrogate");
+        }
+    }
 }

--- a/tests/PrettyPrompt.Tests/GraphemeTests.cs
+++ b/tests/PrettyPrompt.Tests/GraphemeTests.cs
@@ -1,0 +1,44 @@
+#region License Header
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#endregion
+
+using PrettyPrompt.Documents;
+using Xunit;
+
+namespace PrettyPrompt.Tests;
+
+public class GraphemeTests
+{
+    // 🤦🏼‍♂️ = U+1F926 U+1F3FC U+200D U+2642 U+FE0F = 7 chars, one grapheme cluster.
+    private const string Emoji = "\U0001F926\U0001F3FC\u200D\u2642\uFE0F";
+
+    // "a" + emoji + "b": 'a'=[0], emoji=[1..8), 'b'=[8], length 9.
+    private const string Text = "a" + Emoji + "b";
+
+    [Theory]
+    [InlineData(0, 1)] // past 'a'
+    [InlineData(1, 8)] // past the whole emoji cluster (not just one surrogate)
+    [InlineData(8, 9)] // past 'b'
+    [InlineData(9, 9)] // clamped at end
+    public void NextBoundary_StepsOverWholeCluster(int index, int expected)
+        => Assert.Equal(expected, Grapheme.NextBoundary(Text, index));
+
+    [Theory]
+    [InlineData(9, 8)] // before 'b'
+    [InlineData(8, 1)] // before the whole emoji cluster
+    [InlineData(1, 0)] // before 'a'
+    [InlineData(0, 0)] // clamped at 0
+    public void PreviousBoundary_StepsOverWholeCluster(int index, int expected)
+        => Assert.Equal(expected, Grapheme.PreviousBoundary(Text, index));
+
+    [Theory]
+    [InlineData(1, 1)] // already on a boundary
+    [InlineData(4, 1)] // inside the emoji -> snap back to its start
+    [InlineData(8, 8)] // already on a boundary
+    [InlineData(0, 0)]
+    [InlineData(9, 9)]
+    public void RoundDownToBoundary_SnapsMidClusterIndices(int index, int expected)
+        => Assert.Equal(expected, Grapheme.RoundDownToBoundary(Text, index));
+}

--- a/tests/PrettyPrompt.Tests/PromptTests.cs
+++ b/tests/PrettyPrompt.Tests/PromptTests.cs
@@ -390,6 +390,38 @@ public class PromptTests
     }
 
     /// <summary>
+    /// https://github.com/waf/PrettyPrompt/issues/270
+    /// Pasting must preserve the zero-width joiners, emoji modifiers, and variation selectors that
+    /// hold a grapheme cluster together - they must not be filtered out as "zero-width" characters,
+    /// otherwise the cluster breaks apart (e.g. 🤦🏼‍♂️ would render as 🤦🏼 followed by ♂).
+    /// </summary>
+    [Fact]
+    public async Task ReadLine_PasteEmojiAndCombiningSequences_ArePreservedIntact()
+    {
+        var console = ConsoleStub.NewConsole();
+        using (console.ProtectClipboard())
+        {
+            const string FacePalm = "\U0001F926\U0001F3FC\u200D\u2642\uFE0F"; // 🤦🏼‍♂️ (ZWJ sequence with VS-16)
+            console.Clipboard.SetText(FacePalm);
+            console.StubInput($"{Control}{V}{Enter}");
+            var prompt = new Prompt(console: console);
+            var result = await prompt.ReadLineAsync();
+            Assert.True(result.IsSuccess);
+            Assert.Equal(FacePalm, result.Text);
+
+            ////////////////////////////////////////////////
+
+            const string Accented = "e\u0301"; // é = base letter + combining acute accent
+            console.Clipboard.SetText(Accented);
+            console.StubInput($"{Control}{V}{Enter}");
+            prompt = new Prompt(console: console);
+            result = await prompt.ReadLineAsync();
+            Assert.True(result.IsSuccess);
+            Assert.Equal(Accented, result.Text);
+        }
+    }
+
+    /// <summary>
     /// https://github.com/waf/PrettyPrompt/issues/151
     /// </summary>
     [Fact]

--- a/tests/PrettyPrompt.Tests/PromptTests.cs
+++ b/tests/PrettyPrompt.Tests/PromptTests.cs
@@ -696,4 +696,39 @@ public class PromptTests
         Assert.Equal("> ", output[1]);
         Assert.Equal("***", output[5]);
     }
+
+    /// <summary>
+    /// https://github.com/waf/PrettyPrompt/issues/270
+    /// Arrow keys, Backspace, and Delete must operate on whole grapheme clusters, not single UTF-16
+    /// code units, so editing around an emoji never splits its surrogate pair / joiners.
+    /// </summary>
+    [Fact]
+    public async Task ReadLine_EditAroundEmoji_TreatsClusterAsOneUnit()
+    {
+        const string Emoji = "\U0001F926\U0001F3FC\u200D\u2642\uFE0F"; // 🤦🏼‍♂️
+        var console = ConsoleStub.NewConsole();
+        using (console.ProtectClipboard())
+        {
+            // Backspace removes the whole cluster (caret is at the end after pasting), then 'b'.
+            console.Clipboard.SetText("a" + Emoji + "b");
+            console.StubInput($"{Control}{V}{Backspace}{Backspace}{Enter}");
+            var prompt = new Prompt(console: console);
+            var result = await prompt.ReadLineAsync();
+            Assert.Equal("a", result.Text);
+
+            // Left arrow steps over the whole cluster: end -> before 'b' -> before the emoji, then insert.
+            console.Clipboard.SetText("a" + Emoji + "b");
+            console.StubInput($"{Control}{V}{LeftArrow}{LeftArrow}x{Enter}");
+            prompt = new Prompt(console: console);
+            result = await prompt.ReadLineAsync();
+            Assert.Equal("ax" + Emoji + "b", result.Text);
+
+            // Delete (forward) removes the whole cluster: Home, delete 'a', delete the emoji.
+            console.Clipboard.SetText("a" + Emoji + "b");
+            console.StubInput($"{Control}{V}{Home}{Delete}{Delete}{Enter}");
+            prompt = new Prompt(console: console);
+            result = await prompt.ReadLineAsync();
+            Assert.Equal("b", result.Text);
+        }
+    }
 }

--- a/tests/PrettyPrompt.Tests/ScreenTests.cs
+++ b/tests/PrettyPrompt.Tests/ScreenTests.cs
@@ -1,4 +1,4 @@
-﻿using PrettyPrompt.Consoles;
+using PrettyPrompt.Consoles;
 using PrettyPrompt.Rendering;
 using Xunit;
 
@@ -11,7 +11,7 @@ public class ScreenTests
     [InlineData("a", 1)]
     [InlineData("ab", 2)]
     [InlineData("abc", 3)]
-    
+
     [InlineData("书", 2)]
     [InlineData("a书", 3)]
     [InlineData("a书bc", 5)]
@@ -39,7 +39,7 @@ public class ScreenTests
     [InlineData("💡", 2)]
     [InlineData("❌", 2)]
     [InlineData("✅", 2)]
-    
+
     //squares
     [InlineData("⬛", 2)]
     [InlineData("🟫", 2)]
@@ -53,6 +53,15 @@ public class ScreenTests
 
     [InlineData("🔷", 2)]
     [InlineData("🔶", 2)]
+
+    // Multi-codepoint grapheme clusters that previously crashed cursor positioning (issue #270).
+    // Each is a single cluster occupying two columns, so the cursor ends up at column 2.
+    // Literals use escapes because the sequences contain invisible joiners/selectors.
+    [InlineData("\U0001F926\U0001F3FC", 2)]                       // 🤦🏼 face palm + Fitzpatrick skin-tone modifier
+    [InlineData("\U0001F926\u200D\u2642", 2)]                     // 🤦‍♂ face palm + ZWJ + male sign
+    [InlineData("\U0001F926\U0001F3FC\u200D\u2642\uFE0F", 2)]     // 🤦🏼‍♂️ full ZWJ sequence with variation selector
+    [InlineData("\u79B0\U000E0100", 2)]                           // 禰󠄀 CJK ideograph + variation selector supplement (U+E0100)
+    [InlineData("a\U0001F926\U0001F3FC", 3)]                      // narrow char then a two-column cluster
     public void ScreenCursorPositionTest(string text, int expectedCursorPosition)
     {
         var screen = new Screen(

--- a/tests/PrettyPrompt.Tests/ScreenTests.cs
+++ b/tests/PrettyPrompt.Tests/ScreenTests.cs
@@ -62,6 +62,10 @@ public class ScreenTests
     [InlineData("\U0001F926\U0001F3FC\u200D\u2642\uFE0F", 2)]     // 🤦🏼‍♂️ full ZWJ sequence with variation selector
     [InlineData("\u79B0\U000E0100", 2)]                           // 禰󠄀 CJK ideograph + variation selector supplement (U+E0100)
     [InlineData("a\U0001F926\U0001F3FC", 3)]                      // narrow char then a two-column cluster
+
+    // base char + combining mark is a single-column cluster: the cursor lands one column past it, not two.
+    [InlineData("e\u0301", 1)]                                    // e + combining acute accent (decomposed "é")
+    [InlineData("ae\u0301b", 3)]                                  // a + combining "é" + b
     public void ScreenCursorPositionTest(string text, int expectedCursorPosition)
     {
         var screen = new Screen(

--- a/tests/PrettyPrompt.Tests/UnicodeWidthTests.cs
+++ b/tests/PrettyPrompt.Tests/UnicodeWidthTests.cs
@@ -1,0 +1,58 @@
+#region License Header
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#endregion
+
+using PrettyPrompt.Rendering;
+using Xunit;
+
+namespace PrettyPrompt.Tests;
+
+public class UnicodeWidthTests
+{
+    [Theory]
+    // basics
+    [InlineData("", 0)]
+    [InlineData("a", 1)]
+    [InlineData("abc", 3)]
+    [InlineData("\u4E66", 2)]            // 书 full-width CJK
+    [InlineData("a\u4E66bc", 5)]         // mixed narrow + wide
+
+    // single emoji (supplementary plane)
+    [InlineData("\U0001F600", 2)]        // 😀
+
+    // multi-codepoint grapheme clusters from issue #270 — each is a single two-column cell,
+    // NOT the sum of its parts (which previously produced widths of 3-5 and crashed).
+    [InlineData("\U0001F926\U0001F3FC", 2)]                       // 🤦🏼 base + skin-tone modifier
+    [InlineData("\U0001F926\u200D\u2642", 2)]                     // 🤦‍♂ base + ZWJ + male sign
+    [InlineData("\U0001F926\U0001F3FC\u200D\u2642\uFE0F", 2)]     // 🤦🏼‍♂️ full ZWJ sequence
+    [InlineData("\u79B0\U000E0100", 2)]                           // 禰󠄀 CJK + variation selector supplement (U+E0100)
+
+    // base char + combining mark is one column (the trailing mark adds nothing)
+    [InlineData("e\u0301", 1)]                                    // é = e + combining acute accent
+
+    // multiple clusters sum their (capped) widths
+    [InlineData("a\U0001F926\U0001F3FCb", 4)]                     // narrow + two-column cluster + narrow
+
+    // narrow supplementary glyph that the old code mis-sized (issue called this out): a playing card is 1
+    [InlineData("\U0001F0A1", 1)]                                 // 🂡 playing card ace of spades
+    public void GetWidth_ReturnsExpectedDisplayWidth(string text, int expectedWidth)
+    {
+        Assert.Equal(expectedWidth, UnicodeWidth.GetWidth(text));
+    }
+
+    [Theory]
+    // a single grapheme cluster never exceeds two columns, regardless of how many scalars it contains
+    [InlineData("\U0001F926", 2)]                                 // 🤦
+    [InlineData("\U0001F926\U0001F3FC", 2)]                       // 🤦🏼
+    [InlineData("\U0001F926\U0001F3FC\u200D\u2642\uFE0F", 2)]     // 🤦🏼‍♂️
+    [InlineData("\u79B0\U000E0100", 2)]                           // 禰󠄀
+    [InlineData("a", 1)]                                          // narrow
+    [InlineData("\u4E66", 2)]                                     // 书 wide
+    public void GetGraphemeClusterWidth_IsCappedAtTwo(string cluster, int expectedWidth)
+    {
+        Assert.Equal(expectedWidth, UnicodeWidth.GetGraphemeClusterWidth(cluster));
+        Assert.InRange(UnicodeWidth.GetGraphemeClusterWidth(cluster), 0, 2);
+    }
+}

--- a/tests/PrettyPrompt.Tests/UnicodeWidthTests.cs
+++ b/tests/PrettyPrompt.Tests/UnicodeWidthTests.cs
@@ -55,4 +55,15 @@ public class UnicodeWidthTests
         Assert.Equal(expectedWidth, UnicodeWidth.GetGraphemeClusterWidth(cluster));
         Assert.InRange(UnicodeWidth.GetGraphemeClusterWidth(cluster), 0, 2);
     }
+
+    [Theory]
+    // GetLengthThatFits returns a CHAR count whose display width fits the column budget, on a cluster boundary.
+    [InlineData("abcde", 3, 3)]                          // narrow: 3 columns == 3 chars
+    [InlineData("\u4E66\u4E66\u4E66", 4, 2)]                          // each wide char is 2 columns; 4 columns fits 2 chars
+    [InlineData("\u4E66\u4E66\u4E66", 5, 2)]                          // 5 columns: a 3rd wide char would be 6, so stop at 2 chars
+    [InlineData("a\u4E66", 1, 1)]                            // 'a' fits 1 column; 书 would overflow
+    [InlineData("\U0001F926\U0001F3FC\u200D\u2642\uFE0Fx", 2, 7)]  // the width-2 emoji (7 chars) fits in 2 columns; 'x' would not
+    [InlineData("\U0001F926\U0001F3FC\u200D\u2642\uFE0Fx", 1, 0)]  // the emoji is 2 columns wide and cannot fit in 1
+    public void GetLengthThatFits_TruncatesByWidthOnClusterBoundary(string text, int maxWidth, int expectedLength)
+        => Assert.Equal(expectedLength, UnicodeWidth.GetLengthThatFits(text, maxWidth));
 }


### PR DESCRIPTION
Character navigation / rendering / clipboard fixes for unicode characters.

Drops the wcwidth implementation and use https://github.com/spectreconsole/wcwidth (source-only package) instead.

This fixes a whole host of issues around emojis + zero-width-joiners