### PR TITLE
Narrow the scope at which we DISABLE_NEWLINE_AUTO_RETURN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
-# Release 5.0.3 (unreleased)
+# Release 6.0.0
 
+- Breaking change (Windows behavior): the `DISABLE_NEWLINE_AUTO_RETURN` console mode is now only active while `ReadLineAsync` is rendering, instead of being enabled process-wide by the `Prompt` constructor.
+    - Previously, any `"\n"` the host application wrote to stdout between prompts performed a line feed *without* returning the cursor to the first column. Such output now renders normally.
+    - Applications that compensated by writing `"\r\n"` (or `Environment.NewLine`) are unaffected, but code that relied on the line-feed-only semantics between prompts must now call the new `IConsole.SetNewlineAutoReturn(false)` itself.
 - Fix `ArgumentOutOfRangeException` crash when the overload (signature help) pane and the completion pane are open with exactly equal widths and no documentation pane is visible.
 
 # Release 5.0.2

--- a/src/PrettyPrompt/Console/IConsole.cs
+++ b/src/PrettyPrompt/Console/IConsole.cs
@@ -62,6 +62,16 @@ public interface IConsole
     /// </summary>
     void InitVirtualTerminalProcessing();
 
+    /// <summary>
+    /// Controls whether writing a line feed ("\n") also returns the cursor to the first column.
+    /// The prompt disables auto-return while it renders (the renderer positions the cursor with explicit
+    /// escape codes and requires "\n" to be a pure line feed), and re-enables it when
+    /// <see cref="Prompt.ReadLineAsync"/> returns, so output written by the host application between
+    /// prompts behaves normally. Only meaningful on Windows (the DISABLE_NEWLINE_AUTO_RETURN console mode
+    /// flag); terminals on other platforms translate "\n" to "\r\n" themselves via the ONLCR output flag.
+    /// </summary>
+    void SetNewlineAutoReturn(bool enabled) { }
+
     event ConsoleCancelEventHandler CancelKeyPress;
 
     #region Write StringBuilder default implementations

--- a/src/PrettyPrompt/Console/SystemConsole.cs
+++ b/src/PrettyPrompt/Console/SystemConsole.cs
@@ -48,20 +48,36 @@ public class SystemConsole : IConsole
         remove => Console.CancelKeyPress -= value;
     }
 
+    private const int STD_OUTPUT_HANDLE = -11;
+    private const uint ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004;
+    private const uint DISABLE_NEWLINE_AUTO_RETURN = 0x0008;
+
     public void InitVirtualTerminalProcessing()
     {
         if (!OperatingSystem.IsWindows()) return;
 
         // enable writing ansi escape output
-        const int STD_OUTPUT_HANDLE = -11;
-        const uint ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004;
-        const uint DISABLE_NEWLINE_AUTO_RETURN = 0x0008;
-        var iStdOut = GetStdHandle(STD_OUTPUT_HANDLE);
-        if (!GetConsoleMode(iStdOut, out uint outConsoleMode) ||
-            !SetConsoleMode(iStdOut, outConsoleMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING | DISABLE_NEWLINE_AUTO_RETURN))
+        if (!TryModifyOutputConsoleMode(setFlags: ENABLE_VIRTUAL_TERMINAL_PROCESSING, clearFlags: 0))
         {
             throw new InvalidOperationException($"failed to set output console mode, error code: {Marshal.GetLastWin32Error()}");
         }
+    }
+
+    public void SetNewlineAutoReturn(bool enabled)
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        // best-effort: when output is redirected there's no console mode to modify, and rendering is moot anyway.
+        _ = enabled
+            ? TryModifyOutputConsoleMode(setFlags: 0, clearFlags: DISABLE_NEWLINE_AUTO_RETURN)
+            : TryModifyOutputConsoleMode(setFlags: DISABLE_NEWLINE_AUTO_RETURN, clearFlags: 0);
+    }
+
+    private static bool TryModifyOutputConsoleMode(uint setFlags, uint clearFlags)
+    {
+        var iStdOut = GetStdHandle(STD_OUTPUT_HANDLE);
+        return GetConsoleMode(iStdOut, out uint outConsoleMode)
+            && SetConsoleMode(iStdOut, (outConsoleMode | setFlags) & ~clearFlags);
     }
 
     [DllImport("kernel32", SetLastError = true)]

--- a/src/PrettyPrompt/Documents/WordWrapping.cs
+++ b/src/PrettyPrompt/Documents/WordWrapping.cs
@@ -35,6 +35,7 @@ internal static class WordWrapping
         int currentLineLength = 0;
         var line = StringBuilderPool.Shared.Get(width);
         int textIndex = 0;
+        int charsDroppedFromLine = 0;
         int cursorColumn = 0;
         int cursorRow = 0;
         foreach (var chunkMemory in input.GetChunks())
@@ -43,6 +44,21 @@ internal static class WordWrapping
             for (var i = 0; i < chunk.Length; i++)
             {
                 char character = chunk[i];
+
+                // treat "\r\n" as a single line break: drop the '\r' from the wrapped content (a literal
+                // carriage return rendered to the terminal desyncs the renderer's cursor tracking), but still
+                // advance textIndex so WrappedLine.StartIndex keeps matching offsets into the original text
+                // (callers' highlight spans are keyed to them). Editable input is normalized to '\n' before it
+                // reaches the document; this matters for Prompt.RenderAnsiOutput, which accepts arbitrary text.
+                if (character == '\r' &&
+                    textIndex + 1 < input.Length &&
+                    (i + 1 < chunk.Length ? chunk[i + 1] : input[textIndex + 1]) == '\n')
+                {
+                    textIndex++;
+                    charsDroppedFromLine++;
+                    continue;
+                }
+
                 line.Append(character);
                 bool isCursorPastCharacter = caret > textIndex;
 
@@ -69,16 +85,17 @@ internal static class WordWrapping
                         cursorRow++;
                         cursorColumn = 0;
                     }
-                    lines.Add(new WrappedLine(textIndex - line.Length, line.ToString()));
+                    lines.Add(new WrappedLine(textIndex - line.Length - charsDroppedFromLine, line.ToString()));
                     line.Clear();
                     currentLineLength = 0;
+                    charsDroppedFromLine = 0;
                 }
             }
         }
 
         if (currentLineLength > 0 || input[^1] == '\n')
         {
-            lines.Add(new WrappedLine(textIndex - line.Length, line.ToString()));
+            lines.Add(new WrappedLine(textIndex - line.Length - charsDroppedFromLine, line.ToString()));
         }
 
         Debug.Assert(textIndex == input.Length);

--- a/src/PrettyPrompt/Prompt.cs
+++ b/src/PrettyPrompt/Prompt.cs
@@ -60,6 +60,22 @@ public sealed class Prompt : IPrompt, IAsyncDisposable
     /// <inheritdoc cref="IPrompt.ReadLineAsync()" />
     public async Task<PromptResult> ReadLineAsync()
     {
+        // the incremental renderer positions the cursor with explicit escape codes and requires "\n" to be
+        // a pure line feed (no implicit return to the first column). Scope that mode to the prompt, so that
+        // output written by the host application between prompts uses standard newline behavior.
+        console.SetNewlineAutoReturn(false);
+        try
+        {
+            return await ReadLineCoreAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            console.SetNewlineAutoReturn(true);
+        }
+    }
+
+    private async Task<PromptResult> ReadLineCoreAsync()
+    {
         using var renderer = new Renderer(console, configuration);
 
         // code pane contains the code the user is typing. It does not include the prompt (i.e. "> ")

--- a/tests/PrettyPrompt.Tests/OutputTests.cs
+++ b/tests/PrettyPrompt.Tests/OutputTests.cs
@@ -33,6 +33,28 @@ public class OutputTests
     }
 
     [Fact]
+    public void RenderAnsiOutput_WindowsLineEndings_RenderSameAsUnixLineEndings()
+    {
+        var unix = Prompt.RenderAnsiOutput("line one\nline two\nline three", System.Array.Empty<FormatSpan>(), 100);
+        var windows = Prompt.RenderAnsiOutput("line one\r\nline two\r\nline three", System.Array.Empty<FormatSpan>(), 100);
+
+        Assert.Equal(unix, windows);
+    }
+
+    [Fact]
+    public void RenderAnsiOutput_WindowsLineEndingsWithFormat_SpansUseOriginalTextOffsets()
+    {
+        var format = new ConsoleFormat(Foreground: Red);
+
+        // spans are keyed to offsets in the text as supplied, so "two" in "one\r\ntwo" starts at 5 (not 4).
+        var unix = Prompt.RenderAnsiOutput("one\ntwo", new[] { new FormatSpan(4, 3, format) }, 100);
+        var windows = Prompt.RenderAnsiOutput("one\r\ntwo", new[] { new FormatSpan(5, 3, format) }, 100);
+
+        Assert.Equal(unix, windows);
+        Assert.Contains(ToAnsiEscapeSequenceSlow(format) + "two", windows);
+    }
+
+    [Fact]
     public void RenderAnsiOutput_GivenFormatAndWrapping_AppliesAnsiEscapeSequences()
     {
         var format1 = new ConsoleFormat(Foreground: Red);

--- a/tests/PrettyPrompt.Tests/WordWrappingTests.cs
+++ b/tests/PrettyPrompt.Tests/WordWrappingTests.cs
@@ -28,6 +28,36 @@ public class WordWrappingTests
     }
 
     [Fact]
+    public void WrapEditableCharacters_WindowsLineEndings_TreatedAsSingleLineBreak()
+    {
+        // "\r\n" must wrap exactly like "\n": the '\r' is dropped from the line content (a literal carriage
+        // return would corrupt rendering), but StartIndex still refers to offsets in the original text.
+        var text = "ab\r\ncd\r\n";
+        var wrapped = WordWrapping.WrapEditableCharacters(new StringBuilder(text), caret: 0, width: 20);
+
+        Assert.Equal(
+            new[]
+            {
+                new WrappedLine(0, "ab\n"),
+                new WrappedLine(4, "cd\n"),
+                // text ending in a line break always yields a trailing empty line, same as "\n"-only input
+                new WrappedLine(8, ""),
+            },
+            wrapped.WrappedLines
+        );
+    }
+
+    [Fact]
+    public void WrapEditableCharacters_LoneCarriageReturn_IsLeftUntouched()
+    {
+        // only the '\r' of a "\r\n" pair is dropped; a lone '\r' stays in the content as before.
+        var text = "ab\rcd";
+        var wrapped = WordWrapping.WrapEditableCharacters(new StringBuilder(text), caret: 0, width: 20);
+
+        Assert.Equal(new[] { new WrappedLine(0, "ab\rcd") }, wrapped.WrappedLines);
+    }
+
+    [Fact]
     public void WrapEditableCharacters_DoubleWidthCharacters_UsesStringWidth()
     {
         var text = "每个人都有他的作战策略，直到脸上中了一拳。";


### PR DESCRIPTION
We were setting DISABLE_NEWLINE_AUTO_RETURN console mode on startup, and this ultimately causes confusing issues in applications that use PrettyPrompt, e.g. https://github.com/waf/CSharpRepl/issues/387

Instead, only set it when we actually are rendering, rather than globally.

This is a breaking change for applications that depended on DISABLE_NEWLINE_AUTO_RETURN