### PR TITLE
Mac OS keybinding fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,28 +8,37 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, windows-latest]
 
-    runs-on: windows-latest
+    runs-on: ${{ matrix.platform }}
 
     steps:
-    - uses: actions/checkout@v1
-    
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+
     - name: Install Dotnet
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2
       with:
-        dotnet-version: | 
-          10.0.x
-      
+        dotnet-version: '10.0.x'
+
     - name: Dotnet Installation Info
       run: dotnet --info
-      
+
     - name: Build
       run: dotnet build
-      
-    - name: Test
+
+    # Coverage is only uploaded from the Windows run (see below), so Linux doesn't need --coverage.
+    - name: Test (Linux)
+      if: matrix.platform == 'ubuntu-latest'
+      run: dotnet test tests/PrettyPrompt.Tests/PrettyPrompt.Tests.csproj --no-build --results-directory TestResults
+
+    - name: Test (Windows, with coverage)
+      if: matrix.platform == 'windows-latest'
       run: dotnet test tests/PrettyPrompt.Tests/PrettyPrompt.Tests.csproj --no-build --results-directory TestResults --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml
 
     - name: Report Code Coverage
+      if: matrix.platform == 'windows-latest' # only generate and upload code coverage once
       uses: codecov/codecov-action@260aa3b4b2f265b8578bc0e721e33ebf8ff53313
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/src/PrettyPrompt/Console/AnsiEscapeCodes.cs
+++ b/src/PrettyPrompt/Console/AnsiEscapeCodes.cs
@@ -23,6 +23,14 @@ public static class AnsiEscapeCodes
     public const string ClearEntireScreen = $"{Escape}[2J";
     public static readonly string Reset = $"{Escape}[{ResetChar}m";
 
+    // xterm "modifyOtherKeys" (XTMODKEYS, resource Pp=4). When enabled, combinations that otherwise
+    // share an encoding with an unmodified key - notably Shift/Ctrl/Alt+Enter, which all arrive as a
+    // bare CR - are reported as distinct "CSI 27 ; <modifier> ; <keycode> ~" sequences, which we parse
+    // in KeyPress.MapInputEscapeSequence. Level 2 is required: level 1 explicitly excludes the "well
+    // known" keys (Enter, Tab, Backspace, Escape). See https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
+    public const string EnableModifyOtherKeys = $"{Escape}[>4;2m";
+    public const string DisableModifyOtherKeys = $"{Escape}[>4;0m";
+
     /// <param name="index">Index starts at 1.</param>
     public static string GetMoveCursorToColumn(int index) => $"{Escape}[{index}G";
 

--- a/src/PrettyPrompt/Console/IConsole.cs
+++ b/src/PrettyPrompt/Console/IConsole.cs
@@ -72,6 +72,17 @@ public interface IConsole
     /// </summary>
     void SetNewlineAutoReturn(bool enabled) { }
 
+    /// <summary>
+    /// Enables xterm "modifyOtherKeys" mode for the duration of the prompt, so that key combinations
+    /// that normally share an encoding with an unmodified key (Shift/Ctrl/Alt+Enter all otherwise arrive
+    /// as a bare CR, indistinguishable from plain Enter) are reported as distinct CSI 27 escape sequences
+    /// that <see cref="KeyPress"/> can parse. The prompt enables this on entry and resets it when
+    /// <see cref="Prompt.ReadLineAsync"/> returns. This is only relevant on Unix/macOS, where .NET
+    /// reconstructs keys from the terminal byte stream; on Windows the key events already carry modifiers.
+    /// No-op for non-system consoles (e.g. unit-test stubs).
+    /// </summary>
+    void SetModifyOtherKeys(bool enabled) { }
+
     event ConsoleCancelEventHandler CancelKeyPress;
 
     #region Write StringBuilder default implementations

--- a/src/PrettyPrompt/Console/KeyPress.cs
+++ b/src/PrettyPrompt/Console/KeyPress.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace PrettyPrompt.Consoles;
@@ -106,6 +107,15 @@ public class KeyPress
     private static KeyPress? MapInputEscapeSequence(List<ConsoleKeyInfo> keys)
     {
         var sequence = new string(keys.Select(key => key.KeyChar).ToArray());
+
+        // xterm "modifyOtherKeys" reports otherwise-ambiguous combinations (Shift/Ctrl/Alt + Enter, which
+        // all normally arrive as a bare CR) as ESC [ 27 ; <modifier> ; <keycode> ~. Handle it before the
+        // literal lookups below, since the modifier and keycode vary. See AnsiEscapeCodes.EnableModifyOtherKeys.
+        if (TryMapModifyOtherKeys(sequence, out var modifiedKeyPress))
+        {
+            return modifiedKeyPress;
+        }
+
         return sequence switch
         {
             "\u001b1;5P" => new KeyPress(ConsoleKey.F1.ToKeyInfo('\0', control: true)),
@@ -122,6 +132,42 @@ public class KeyPress
             "\u001b24;5~" => new KeyPress(ConsoleKey.F12.ToKeyInfo('\0', control: true)),
             _ => null
         };
+    }
+
+    /// <summary>
+    /// Parses an xterm "modifyOtherKeys" CSI 27 sequence of the form ESC [ 27 ; modifier ; keycode ~.
+    /// The modifier is encoded as 1 + a bitmask of Shift(1), Alt(2), Control(4). We only special-case the
+    /// Enter key (keycode 13) here - the combination that's otherwise lost on Unix/macOS; any other key is
+    /// left to .NET's normal handling. .NET's Unix console parser strips the leading '[' (compare the
+    /// function-key sequences above, which also lack it), so both forms are accepted.
+    /// </summary>
+    private static bool TryMapModifyOtherKeys(string sequence, [NotNullWhen(true)] out KeyPress? keyPress)
+    {
+        keyPress = null;
+
+        string body;
+        if (sequence.StartsWith("[27;", StringComparison.Ordinal)) body = sequence[2..];
+        else if (sequence.StartsWith("27;", StringComparison.Ordinal)) body = sequence[1..];
+        else return false;
+
+        if (!body.EndsWith("~", StringComparison.Ordinal)) return false;
+
+        var parts = body[..^1].Split(';'); // ["27", "<modifier>", "<keycode>"]
+        if (parts.Length != 3 ||
+            !int.TryParse(parts[1], out var modifier) ||
+            !int.TryParse(parts[2], out var keyCode) ||
+            keyCode != 13) // 13 == '\r'; only Enter is ambiguous enough to need this.
+        {
+            return false;
+        }
+
+        var modifierMask = modifier - 1;
+        keyPress = new KeyPress(ConsoleKey.Enter.ToKeyInfo(
+            '\r', // the KeyPress constructor normalizes this to '\n' while preserving the modifiers.
+            shift: (modifierMask & 1) != 0,
+            alt: (modifierMask & 2) != 0,
+            control: (modifierMask & 4) != 0));
+        return true;
     }
 
     /// <summary>

--- a/src/PrettyPrompt/Console/SystemConsole.cs
+++ b/src/PrettyPrompt/Console/SystemConsole.cs
@@ -73,6 +73,12 @@ public class SystemConsole : IConsole
             : TryModifyOutputConsoleMode(setFlags: DISABLE_NEWLINE_AUTO_RETURN, clearFlags: 0);
     }
 
+    public void SetModifyOtherKeys(bool enabled)
+        // A pure ANSI sequence (unlike the Windows console-mode flags above), so it goes out the normal
+        // output stream. Terminals that don't understand it ignore it. Harmless on Windows: .NET reads
+        // keys via ReadConsoleInput, not the VT input stream, so it doesn't change how keys are reported.
+        => Write(enabled ? AnsiEscapeCodes.EnableModifyOtherKeys : AnsiEscapeCodes.DisableModifyOtherKeys);
+
     private static bool TryModifyOutputConsoleMode(uint setFlags, uint clearFlags)
     {
         var iStdOut = GetStdHandle(STD_OUTPUT_HANDLE);

--- a/src/PrettyPrompt/Prompt.cs
+++ b/src/PrettyPrompt/Prompt.cs
@@ -64,12 +64,16 @@ public sealed class Prompt : IPrompt, IAsyncDisposable
         // a pure line feed (no implicit return to the first column). Scope that mode to the prompt, so that
         // output written by the host application between prompts uses standard newline behavior.
         console.SetNewlineAutoReturn(false);
+        // ask the terminal to report modified Enter (Shift/Ctrl/Alt+Enter) as distinct escape sequences;
+        // without this they all arrive as a bare CR on Unix/macOS. Scoped to the prompt and reset below.
+        console.SetModifyOtherKeys(true);
         try
         {
             return await ReadLineCoreAsync().ConfigureAwait(false);
         }
         finally
         {
+            console.SetModifyOtherKeys(false);
             console.SetNewlineAutoReturn(true);
         }
     }

--- a/tests/PrettyPrompt.Tests/ChineseJapaneseKoreanTests.cs
+++ b/tests/PrettyPrompt.Tests/ChineseJapaneseKoreanTests.cs
@@ -1,4 +1,5 @@
-﻿using PrettyPrompt.Consoles;
+﻿using System;
+using PrettyPrompt.Consoles;
 using System.Threading.Tasks;
 using Xunit;
 using static System.ConsoleKey;
@@ -88,7 +89,10 @@ public class ChineseJapaneseKoreanTests
         Assert.Equal("> ", output[1]);
         Assert.Equal("书", output[2]);
         Assert.Equal("桌", output[3]);
-        Assert.Equal("上\n" + AnsiEscapeCodes.GetMoveCursorLeft(5), output[4]);
+        // After the wrap "\n", Windows preserves the column and moves left 5 to the next line's content; other
+        // platforms return to column 1 (ONLCR), then the full-width char's advance leaves a 1-column move-right.
+        var afterWrap = OperatingSystem.IsWindows() ? AnsiEscapeCodes.GetMoveCursorLeft(5) : AnsiEscapeCodes.GetMoveCursorRight(1);
+        Assert.Equal("上\n" + afterWrap, output[4]);
         Assert.Equal("有", output[5]);
     }
 }

--- a/tests/PrettyPrompt.Tests/ClipboardTests.cs
+++ b/tests/PrettyPrompt.Tests/ClipboardTests.cs
@@ -19,6 +19,13 @@ public class ClipboardTests
     [Fact]
     public async Task Clipboard_WrappedCopyPasting()
     {
+        // This exercises the real OS clipboard (TextCopy). On Linux that needs an X selection - i.e. xsel and
+        // a running display - which headless CI lacks. macOS (pbcopy/pbpaste) and Windows work without extra
+        // setup, so only skip on displayless Linux; the Windows CI run still covers this happy path.
+        Assert.SkipWhen(
+            OperatingSystem.IsLinux() && Environment.GetEnvironmentVariable("DISPLAY") is null,
+            "No X clipboard available (xsel requires a display) on headless Linux.");
+
         var console = ConsoleStub.NewConsole();
         using (console.ProtectClipboard())
         {

--- a/tests/PrettyPrompt.Tests/ConsoleStub.cs
+++ b/tests/PrettyPrompt.Tests/ConsoleStub.cs
@@ -22,8 +22,16 @@ namespace PrettyPrompt.Tests;
 internal static class ConsoleStub
 {
     private static readonly Regex FormatStringSplit = new(@"({\d+}|.)", RegexOptions.Compiled);
-    private static readonly Semaphore semaphore = new(1, 1, nameof(ConsoleStub) + "Semaphore"); //interprocess
+    private static readonly Semaphore semaphore = CreateClipboardSemaphore();
     private static bool isClipboardProtected;
+
+    // Named semaphores are interprocess, but only Windows (and Linux) support them - macOS throws
+    // PlatformNotSupportedException. The state this guards (isClipboardProtected and the in-memory
+    // StubClipboard) is per-process anyway, so an unnamed semaphore is equivalent where named isn't available.
+    private static Semaphore CreateClipboardSemaphore()
+        => OperatingSystem.IsWindows()
+            ? new Semaphore(1, 1, nameof(ConsoleStub) + "Semaphore")
+            : new Semaphore(1, 1);
 
     public static IConsoleWithClipboard NewConsole(int width = 100, int height = 100)
     {

--- a/tests/PrettyPrompt.Tests/KeyPressTests.cs
+++ b/tests/PrettyPrompt.Tests/KeyPressTests.cs
@@ -26,6 +26,14 @@ public class KeyPressTests
                 ($"\u001b21;5~", ConsoleKey.F10, ConsoleModifiers.Control),
                 ($"\u001b23;5~", ConsoleKey.F11, ConsoleModifiers.Control),
                 ($"\u001b24;5~", ConsoleKey.F12, ConsoleModifiers.Control),
+                // xterm modifyOtherKeys: ESC [ 27 ; <modifier> ; 13 ~ for the various Enter combinations.
+                // .NET strips the leading '[', but the parser accepts it either way (last case keeps it).
+                ($"27;2;13~", ConsoleKey.Enter, ConsoleModifiers.Shift),
+                ($"27;3;13~", ConsoleKey.Enter, ConsoleModifiers.Alt),
+                ($"27;5;13~", ConsoleKey.Enter, ConsoleModifiers.Control),
+                ($"27;6;13~", ConsoleKey.Enter, ConsoleModifiers.Control | ConsoleModifiers.Shift),
+                ($"27;1;13~", ConsoleKey.Enter, 0),
+                ($"[27;2;13~", ConsoleKey.Enter, ConsoleModifiers.Shift),
                 ($"a", ConsoleKey.A, 0),
                 ($"pasted text", ConsoleKey.Insert, ConsoleModifiers.Shift)
         };

--- a/tests/PrettyPrompt.Tests/OutputTests.cs
+++ b/tests/PrettyPrompt.Tests/OutputTests.cs
@@ -1,4 +1,5 @@
-﻿using PrettyPrompt.Highlighting;
+﻿using System;
+using PrettyPrompt.Highlighting;
 using Xunit;
 using static PrettyPrompt.Consoles.AnsiEscapeCodes;
 using static PrettyPrompt.Highlighting.AnsiColor;
@@ -65,12 +66,16 @@ public class OutputTests
                 new FormatSpan(8, 4, format2),
         }, 4);
 
+        // After "\n", Windows preserves the column and moves left 3 back to the wrapped line's start. On other
+        // platforms the terminal returns to column 1 (ONLCR); the origin here is column 0, so the renderer's
+        // reset-to-column-1 leaves a 1-column move-left. The final move (after "put", no newline) is unaffected.
+        var afterWrap = OperatingSystem.IsWindows() ? GetMoveCursorLeft(3) : GetMoveCursorLeft(1);
         Assert.Equal(
             expected:
-                ToAnsiEscapeSequenceSlow(format1) + "here\n" + GetMoveCursorLeft(3) +
-                Reset + " is \n" + GetMoveCursorLeft(3) +
-                ToAnsiEscapeSequenceSlow(format2) + "some\n" + GetMoveCursorLeft(3) +
-                Reset + " out\n" + GetMoveCursorLeft(3) +
+                ToAnsiEscapeSequenceSlow(format1) + "here\n" + afterWrap +
+                Reset + " is \n" + afterWrap +
+                ToAnsiEscapeSequenceSlow(format2) + "some\n" + afterWrap +
+                Reset + " out\n" + afterWrap +
                 "put" + GetMoveCursorLeft(3),
             actual: output
         );

--- a/tests/PrettyPrompt.Tests/PromptTests.cs
+++ b/tests/PrettyPrompt.Tests/PromptTests.cs
@@ -100,10 +100,13 @@ public class PromptTests
 
         var finalOutput = console.GetFinalOutput();
 
+        // After "\n", Windows preserves the cursor column (DISABLE_NEWLINE_AUTO_RETURN) and moves left to the
+        // wrapped line's start; other platforms return to column 1 (ONLCR) and move right to it.
+        var moveToWrappedLine = OperatingSystem.IsWindows() ? GetMoveCursorLeft(2) : GetMoveCursorRight(2);
         Assert.Equal(
-            expected: "111\n" + GetMoveCursorLeft(2) +
-                      "222\n" + GetMoveCursorLeft(2) +
-                      "333\n" + GetMoveCursorLeft(2),
+            expected: "111\n" + moveToWrappedLine +
+                      "222\n" + moveToWrappedLine +
+                      "333\n" + moveToWrappedLine,
             actual: finalOutput
         );
     }
@@ -542,7 +545,8 @@ public class PromptTests
             var prompt = new Prompt(console: console);
             var result = await prompt.ReadLineAsync();
             Assert.True(result.IsSuccess);
-            Assert.Equal(Text, result.Text);
+            // the prompt normalizes line endings to the environment's newline ("\r\n" on Windows, "\n" elsewhere).
+            Assert.Equal(Text.ReplaceLineEndings(), result.Text);
         }
     }
 

--- a/tests/PrettyPrompt.Tests/RendererTests.cs
+++ b/tests/PrettyPrompt.Tests/RendererTests.cs
@@ -51,7 +51,9 @@ public class RendererTests
 
         // because the console height is 5, with 2 lines of padding, and the cursor is on the final line,
         // we should only render the last 3 lines.  there will be some ansi escape sequences for newlines here as well.
-        const string renderedNewlineWithCursorReposition = " \n[24D";
+        // After "\n", Windows preserves the column (DISABLE_NEWLINE_AUTO_RETURN) and moves left to the next
+        // line's content; other platforms return to column 1 (ONLCR) and move right to it.
+        string renderedNewlineWithCursorReposition = " \n" + (OperatingSystem.IsWindows() ? AnsiEscapeCodes.GetMoveCursorLeft(24) : AnsiEscapeCodes.GetMoveCursorRight(2));
         var expectedRender = string.Join(renderedNewlineWithCursorReposition, typedInput.Split('\n').TakeLast(ConsoleHeight - 2));
         Assert.Equal(expectedRender, output);
     }
@@ -85,8 +87,10 @@ public class RendererTests
 
         // because the console height is 5, with 2 lines of padding, with the cursor on the first line,
         // we should only render the first 3 lines. There will be some ansi escape sequences for newlines here as well.
-        const string renderedNewlineWithCursorReposition = " \n[24D";
-        const string cursorRepositionToFirstLine = " \n[3A[24D";
+        // After "\n", Windows preserves the column (DISABLE_NEWLINE_AUTO_RETURN) and moves left to the next
+        // line's content; other platforms return to column 1 (ONLCR) and move right to it.
+        string renderedNewlineWithCursorReposition = " \n" + (OperatingSystem.IsWindows() ? AnsiEscapeCodes.GetMoveCursorLeft(24) : AnsiEscapeCodes.GetMoveCursorRight(2));
+        string cursorRepositionToFirstLine = " \n" + AnsiEscapeCodes.GetMoveCursorUp(3) + (OperatingSystem.IsWindows() ? AnsiEscapeCodes.GetMoveCursorLeft(24) : AnsiEscapeCodes.GetMoveCursorRight(2));
         var expectedRender = string.Join(renderedNewlineWithCursorReposition, typedInput.Split('\n').Take(ConsoleHeight - 2)) + cursorRepositionToFirstLine;
         Assert.Equal(expectedRender, output);
     }


### PR DESCRIPTION
Correctly detect shift+enter (and make ctrl / alt follow the same path) by using xterm control sequences https://invisible-island.net/xterm/ctlseqs/ctlseqs.html

Also, fix unit tests that were asserting windows-only behavior, so failing on Mac OS and Linux. Set up Ubuntu CI to catch this in the future.